### PR TITLE
feat: 体重グラフ機能の実装

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -52,7 +52,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"

--- a/lib/core/services/health_service.dart
+++ b/lib/core/services/health_service.dart
@@ -1,4 +1,5 @@
 import 'package:health/health.dart';
+import 'dart:math' as math;
 
 class HealthService {
   static final HealthService _instance = HealthService._internal();
@@ -79,7 +80,10 @@ class HealthService {
         endTime: now,
       );
 
-      if (data.isEmpty) return null;
+      if (data.isEmpty) {
+        print('体重データが見つかりません');
+        return null;
+      }
 
       // 日付順でソート（最新が先頭）
       data.sort((a, b) => b.dateFrom.compareTo(a.dateFrom));
@@ -114,7 +118,10 @@ class HealthService {
         endTime: now,
       );
 
-      if (data.isEmpty) return null;
+      if (data.isEmpty) {
+        print('体脂肪率データが見つかりません');
+        return null;
+      }
 
       data.sort((a, b) => b.dateFrom.compareTo(a.dateFrom));
       final latestBodyFat = data.first.value as NumericHealthValue;
@@ -638,6 +645,7 @@ class HealthService {
       return [];
     }
   }
+
 
   /// HealthKitが利用可能かチェック
   Future<bool> isHealthKitAvailable() async {

--- a/lib/core/utils/chart_utils.dart
+++ b/lib/core/utils/chart_utils.dart
@@ -1,0 +1,153 @@
+import 'package:fl_chart/fl_chart.dart';
+import '../services/health_service.dart';
+
+/// チャート関連のユーティリティクラス
+class ChartUtils {
+  /// 7日移動平均を計算
+  static List<FlSpot> calculateMovingAverage(
+    List<WeightData> data, 
+    int period,
+  ) {
+    if (data.length < period) return [];
+    
+    List<FlSpot> movingAverageSpots = [];
+    
+    for (int i = period - 1; i < data.length; i++) {
+      double sum = 0;
+      for (int j = i - period + 1; j <= i; j++) {
+        sum += data[j].weight;
+      }
+      double average = sum / period;
+      
+      movingAverageSpots.add(FlSpot(i.toDouble(), average));
+    }
+    
+    return movingAverageSpots;
+  }
+  
+  /// WeightDataをFlSpotに変換
+  static List<FlSpot> convertToFlSpots(List<WeightData> data) {
+    return data.asMap().entries.map((entry) {
+      return FlSpot(entry.key.toDouble(), entry.value.weight);
+    }).toList();
+  }
+  
+  /// チャートデータの有効性をチェック
+  static List<FlSpot> validateChartData(List<FlSpot> spots) {
+    return spots.where((spot) => 
+      !spot.x.isNaN && 
+      !spot.y.isNaN && 
+      spot.x.isFinite && 
+      spot.y.isFinite
+    ).toList();
+  }
+  
+  /// データのダウンサンプリング（パフォーマンス向上）
+  static List<WeightData> downsampleData(List<WeightData> data, int maxPoints) {
+    if (data.length <= maxPoints) return data;
+    
+    final step = data.length / maxPoints;
+    List<WeightData> downsampled = [];
+    
+    for (int i = 0; i < maxPoints; i++) {
+      final index = (i * step).round();
+      if (index < data.length) {
+        downsampled.add(data[index]);
+      }
+    }
+    
+    return downsampled;
+  }
+  
+  /// チャートの安全な境界を計算
+  static ChartBounds calculateSafeBounds(List<FlSpot> spots, {double padding = 1.0}) {
+    if (spots.isEmpty) {
+      return ChartBounds(minX: 0, maxX: 1, minY: 0, maxY: 100);
+    }
+    
+    double minX = spots.map((s) => s.x).reduce((a, b) => a < b ? a : b);
+    double maxX = spots.map((s) => s.x).reduce((a, b) => a > b ? a : b);
+    double minY = spots.map((s) => s.y).reduce((a, b) => a < b ? a : b);
+    double maxY = spots.map((s) => s.y).reduce((a, b) => a > b ? a : b);
+    
+    // パディングを追加
+    final yRange = maxY - minY;
+    final yPadding = yRange * 0.1 + padding;
+    
+    return ChartBounds(
+      minX: minX,
+      maxX: maxX,
+      minY: minY - yPadding,
+      maxY: maxY + yPadding,
+    );
+  }
+  
+  /// 最適なグリッド間隔を取得
+  static double getOptimalInterval(int dataPointCount) {
+    if (dataPointCount <= 10) return 1.0;
+    if (dataPointCount <= 30) return 2.0;
+    if (dataPointCount <= 60) return 5.0;
+    return 10.0;
+  }
+  
+  /// 日付を軸ラベル用にフォーマット
+  static String formatDateForAxis(DateTime date, int totalPoints) {
+    if (totalPoints <= 30) {
+      return '${date.month}/${date.day}';
+    } else if (totalPoints <= 60) {
+      return date.day == 1 ? '${date.month}月' : '';
+    } else {
+      return date.day == 1 && date.month % 2 == 1 ? '${date.month}月' : '';
+    }
+  }
+  
+  /// 体重の傾向を分析
+  static WeightTrend analyzeWeightTrend(List<WeightData> data) {
+    if (data.length < 7) return WeightTrend.stable;
+    
+    final recent = data.take(7).map((d) => d.weight).toList();
+    final older = data.skip(data.length - 7).map((d) => d.weight).toList();
+    
+    final recentAvg = recent.reduce((a, b) => a + b) / recent.length;
+    final olderAvg = older.reduce((a, b) => a + b) / older.length;
+    
+    final difference = recentAvg - olderAvg;
+    
+    if (difference > 0.5) return WeightTrend.increasing;
+    if (difference < -0.5) return WeightTrend.decreasing;
+    return WeightTrend.stable;
+  }
+}
+
+/// チャートの境界値
+class ChartBounds {
+  final double minX;
+  final double maxX;
+  final double minY;
+  final double maxY;
+  
+  ChartBounds({
+    required this.minX,
+    required this.maxX,
+    required this.minY,
+    required this.maxY,
+  });
+}
+
+/// 体重の傾向
+enum WeightTrend {
+  increasing,
+  decreasing,
+  stable;
+  
+  String get displayName {
+    switch (this) {
+      case WeightTrend.increasing:
+        return '増加傾向';
+      case WeightTrend.decreasing:
+        return '減少傾向';
+      case WeightTrend.stable:
+        return '安定';
+    }
+  }
+}

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -8,7 +8,7 @@ import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../providers/database_provider.dart' hide weightHistoryProvider;
 import '../providers/health_provider.dart';
-import '../widgets/weight_chart_widget_enhanced.dart';
+import '../widgets/weight_chart_widget_modern.dart';
 
 class HealthDataPage extends HookConsumerWidget {
   const HealthDataPage({super.key});
@@ -579,17 +579,17 @@ class HealthDataPage extends HookConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidgetEnhanced(
+      data: (weightData) => WeightChartWidgetModern(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidgetEnhanced(
+      loading: () => WeightChartWidgetModern(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidgetEnhanced(
+      error: (error, stack) => WeightChartWidgetModern(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -47,14 +47,10 @@ class HealthDataPage extends HookConsumerWidget {
 
                 // 体重・体脂肪率カード
                 personalData.when(
-                  data: (data) => _buildWeightCard(data),
+                  data: (data) => _buildWeightCard(data, ref),
                   loading: () => _buildLoadingCard(),
                   error: (error, stack) => _buildErrorCard('健康データの取得に失敗しました'),
                 ),
-                SizedBox(height: AppConstants.paddingM.h),
-
-                // 体重グラフカード
-                _buildWeightChartSection(ref),
                 SizedBox(height: AppConstants.paddingM.h),
 
                 // 今日の活動カード
@@ -332,7 +328,7 @@ class HealthDataPage extends HookConsumerWidget {
     );
   }
 
-  Widget _buildWeightCard(PersonalDataTableData? data) {
+  Widget _buildWeightCard(PersonalDataTableData? data, WidgetRef ref) {
     return Container(
       padding: EdgeInsets.all(AppConstants.paddingM.w),
       decoration: BoxDecoration(
@@ -384,33 +380,10 @@ class HealthDataPage extends HookConsumerWidget {
           
           SizedBox(height: AppConstants.paddingM.h),
           
-          // 簡易グラフエリア
-          Container(
-            height: 80.h,
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
-            ),
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.show_chart_rounded,
-                    color: AppColors.textSecondary,
-                    size: 32.w,
-                  ),
-                  SizedBox(height: 4.h),
-                  Text(
-                    '推移グラフ（準備中）',
-                    style: AppTextStyles.caption.copyWith(
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
+          // 体重推移グラフ
+          SizedBox(
+            height: 300.h,
+            child: _buildWeightChartSection(ref),
           ),
         ],
       ),

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -8,7 +8,7 @@ import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../providers/database_provider.dart' hide weightHistoryProvider;
 import '../providers/health_provider.dart';
-import '../widgets/weight_chart_widget.dart';
+import '../widgets/weight_chart_widget_enhanced.dart';
 
 class HealthDataPage extends HookConsumerWidget {
   const HealthDataPage({super.key});
@@ -579,17 +579,17 @@ class HealthDataPage extends HookConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidget(
+      data: (weightData) => WeightChartWidgetEnhanced(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidget(
+      loading: () => WeightChartWidgetEnhanced(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidget(
+      error: (error, stack) => WeightChartWidgetEnhanced(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -382,7 +382,7 @@ class HealthDataPage extends HookConsumerWidget {
           
           // 体重推移グラフ
           SizedBox(
-            height: 300.h,
+            height: 280.h,
             child: _buildWeightChartSection(ref),
           ),
         ],

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -8,7 +8,7 @@ import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../providers/database_provider.dart' hide weightHistoryProvider;
 import '../providers/health_provider.dart';
-import '../widgets/weight_chart_widget_modern.dart';
+import '../widgets/weight_chart_widget_health.dart';
 
 class HealthDataPage extends HookConsumerWidget {
   const HealthDataPage({super.key});
@@ -552,17 +552,17 @@ class HealthDataPage extends HookConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidgetModern(
+      data: (weightData) => WeightChartWidgetHealth(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidgetModern(
+      loading: () => WeightChartWidgetHealth(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidgetModern(
+      error: (error, stack) => WeightChartWidgetHealth(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -8,6 +8,7 @@ import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../providers/database_provider.dart';
 import '../providers/health_provider.dart';
+import '../widgets/weight_chart_widget.dart';
 
 class HealthDataPage extends HookConsumerWidget {
   const HealthDataPage({super.key});
@@ -50,6 +51,10 @@ class HealthDataPage extends HookConsumerWidget {
                   loading: () => _buildLoadingCard(),
                   error: (error, stack) => _buildErrorCard('健康データの取得に失敗しました'),
                 ),
+                SizedBox(height: AppConstants.paddingM.h),
+
+                // 体重グラフカード
+                _buildWeightChartSection(ref),
                 SizedBox(height: AppConstants.paddingM.h),
 
                 // 今日の活動カード
@@ -567,6 +572,30 @@ class HealthDataPage extends HookConsumerWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildWeightChartSection(WidgetRef ref) {
+    final weightHistoryAsync = ref.watch(weightHistoryProvider);
+
+    return weightHistoryAsync.when(
+      data: (weightData) => WeightChartWidget(
+        weightData: weightData,
+        onRefresh: () {
+          ref.invalidate(weightHistoryProvider);
+        },
+      ),
+      loading: () => WeightChartWidget(
+        weightData: const [],
+        isLoading: true,
+      ),
+      error: (error, stack) => WeightChartWidget(
+        weightData: const [],
+        errorMessage: error.toString(),
+        onRefresh: () {
+          ref.invalidate(weightHistoryProvider);
+        },
+      ),
     );
   }
 

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -6,7 +6,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../core/themes/app_colors.dart';
 import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
-import '../providers/database_provider.dart';
+import '../providers/database_provider.dart' hide weightHistoryProvider;
 import '../providers/health_provider.dart';
 import '../widgets/weight_chart_widget.dart';
 

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -381,10 +381,7 @@ class HealthDataPage extends HookConsumerWidget {
           SizedBox(height: AppConstants.paddingM.h),
           
           // 体重推移グラフ
-          SizedBox(
-            height: 280.h,
-            child: _buildWeightChartSection(ref),
-          ),
+          _buildWeightChartSection(ref),
         ],
       ),
     );

--- a/lib/presentation/providers/health_provider.dart
+++ b/lib/presentation/providers/health_provider.dart
@@ -90,6 +90,17 @@ final healthKitAvailabilityProvider = FutureProvider<bool>((ref) async {
   return await healthService.isHealthKitAvailable();
 });
 
+// 体重履歴プロバイダー
+final weightHistoryProvider = FutureProvider<List<WeightData>>((ref) async {
+  final healthService = ref.read(healthServiceProvider);
+  
+  // 権限チェック
+  final hasPermission = await ref.read(healthPermissionProvider.future);
+  if (!hasPermission) return [];
+  
+  return await healthService.getWeightHistory();
+});
+
 // 健康データを統合したプロバイダー（直近24時間のデータ）
 final healthDataSummaryProvider = FutureProvider<HealthDataSummary>((ref) async {
   final healthService = ref.watch(healthServiceProvider);

--- a/lib/presentation/widgets/weight_chart_card.dart
+++ b/lib/presentation/widgets/weight_chart_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/health_provider.dart';
-import 'weight_chart_widget.dart';
+import 'weight_chart_widget_enhanced.dart';
 
 class WeightChartCard extends ConsumerWidget {
   const WeightChartCard({
@@ -17,17 +17,17 @@ class WeightChartCard extends ConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidget(
+      data: (weightData) => WeightChartWidgetEnhanced(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidget(
+      loading: () => WeightChartWidgetEnhanced(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidget(
+      error: (error, stack) => WeightChartWidgetEnhanced(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/widgets/weight_chart_card.dart
+++ b/lib/presentation/widgets/weight_chart_card.dart
@@ -1,99 +1,38 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/themes/app_colors.dart';
-import '../../core/themes/app_text_styles.dart';
-import '../../core/constants/app_constants.dart';
+import '../providers/health_provider.dart';
+import 'weight_chart_widget.dart';
 
-class WeightChartCard extends StatelessWidget {
+class WeightChartCard extends ConsumerWidget {
   const WeightChartCard({
     super.key,
-    required this.weights,
+    required this.weights, // 後方互換性のため残す
   });
 
-  final List<double> weights;
+  final List<double> weights; // 廃止予定、WeightDataを使用
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(AppConstants.paddingM.w),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 8.r,
-            offset: Offset(0, 2.h),
-          ),
-        ],
+  Widget build(BuildContext context, WidgetRef ref) {
+    final weightHistoryAsync = ref.watch(weightHistoryProvider);
+
+    return weightHistoryAsync.when(
+      data: (weightData) => WeightChartWidget(
+        weightData: weightData,
+        onRefresh: () {
+          ref.invalidate(weightHistoryProvider);
+        },
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '体重推移（7日移動平均）',
-            style: AppTextStyles.headline3,
-          ),
-          SizedBox(height: AppConstants.paddingS.h),
-          Text(
-            '過去3ヶ月',
-            style: AppTextStyles.caption.copyWith(
-              color: AppColors.textSecondary,
-            ),
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
-          
-          // 簡易チャート表示（実際のグラフは後で実装）
-          Container(
-            height: 120.h,
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
-            ),
-            child: weights.isEmpty
-                ? Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.show_chart_rounded,
-                          color: AppColors.textSecondary,
-                          size: 32.w,
-                        ),
-                        SizedBox(height: AppConstants.paddingS.h),
-                        Text(
-                          '体重データがありません',
-                          style: AppTextStyles.body2.copyWith(
-                            color: AppColors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  )
-                : Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '${weights.last.toStringAsFixed(1)} kg',
-                          style: AppTextStyles.numberLarge.copyWith(
-                            color: AppColors.primary,
-                          ),
-                        ),
-                        SizedBox(height: AppConstants.paddingS.h),
-                        Text(
-                          '最新の体重',
-                          style: AppTextStyles.caption.copyWith(
-                            color: AppColors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-          ),
-        ],
+      loading: () => WeightChartWidget(
+        weightData: const [],
+        isLoading: true,
+      ),
+      error: (error, stack) => WeightChartWidget(
+        weightData: const [],
+        errorMessage: error.toString(),
+        onRefresh: () {
+          ref.invalidate(weightHistoryProvider);
+        },
       ),
     );
   }

--- a/lib/presentation/widgets/weight_chart_card.dart
+++ b/lib/presentation/widgets/weight_chart_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/health_provider.dart';
-import 'weight_chart_widget_modern.dart';
+import 'weight_chart_widget_home.dart';
 
 class WeightChartCard extends ConsumerWidget {
   const WeightChartCard({
@@ -17,17 +17,17 @@ class WeightChartCard extends ConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidgetModern(
+      data: (weightData) => WeightChartWidgetHome(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidgetModern(
+      loading: () => WeightChartWidgetHome(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidgetModern(
+      error: (error, stack) => WeightChartWidgetHome(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/widgets/weight_chart_card.dart
+++ b/lib/presentation/widgets/weight_chart_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/health_provider.dart';
-import 'weight_chart_widget_enhanced.dart';
+import 'weight_chart_widget_modern.dart';
 
 class WeightChartCard extends ConsumerWidget {
   const WeightChartCard({
@@ -17,17 +17,17 @@ class WeightChartCard extends ConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidgetEnhanced(
+      data: (weightData) => WeightChartWidgetModern(
         weightData: weightData,
         onRefresh: () {
           ref.invalidate(weightHistoryProvider);
         },
       ),
-      loading: () => WeightChartWidgetEnhanced(
+      loading: () => WeightChartWidgetModern(
         weightData: const [],
         isLoading: true,
       ),
-      error: (error, stack) => WeightChartWidgetEnhanced(
+      error: (error, stack) => WeightChartWidgetModern(
         weightData: const [],
         errorMessage: error.toString(),
         onRefresh: () {

--- a/lib/presentation/widgets/weight_chart_widget.dart
+++ b/lib/presentation/widgets/weight_chart_widget.dart
@@ -1,0 +1,509 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'dart:math' as math;
+
+import '../../core/themes/app_text_styles.dart';
+import '../../core/constants/app_constants.dart';
+import '../../core/services/health_service.dart';
+import '../../core/utils/chart_utils.dart';
+
+/// 体重グラフウィジェット（Material Design 3準拠）
+class WeightChartWidget extends StatefulWidget {
+  final List<WeightData> weightData;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRefresh;
+
+  const WeightChartWidget({
+    super.key,
+    required this.weightData,
+    this.isLoading = false,
+    this.errorMessage,
+    this.onRefresh,
+  });
+
+  @override
+  State<WeightChartWidget> createState() => _WeightChartWidgetState();
+}
+
+class _WeightChartWidgetState extends State<WeightChartWidget> 
+    with AutomaticKeepAliveClientMixin {
+  
+  @override
+  bool get wantKeepAlive => true; // ウィジェットの状態を保持
+
+  late List<FlSpot> _cachedWeightSpots;
+  late List<FlSpot> _cachedMovingAverageSpots;
+  late ChartBounds _cachedBounds;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateCachedData();
+  }
+
+  @override
+  void didUpdateWidget(WeightChartWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.weightData != widget.weightData) {
+      _updateCachedData();
+    }
+  }
+
+  void _updateCachedData() {
+    if (widget.weightData.isNotEmpty) {
+      // 最大90ポイントに制限してパフォーマンス向上
+      final processedData = ChartUtils.downsampleData(widget.weightData, 90);
+      _cachedWeightSpots = ChartUtils.validateChartData(
+        ChartUtils.convertToFlSpots(processedData)
+      );
+      _cachedMovingAverageSpots = ChartUtils.validateChartData(
+        ChartUtils.calculateMovingAverage(processedData, 7)
+      );
+      _cachedBounds = ChartUtils.calculateSafeBounds(
+        [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
+        padding: 2.0,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    
+    return Semantics(
+      container: true,
+      label: '体重推移グラフ',
+      hint: '過去3ヶ月の体重変化と1週間移動平均を表示しています。タップして詳細を確認できます',
+      child: _buildChartCard(context),
+    );
+  }
+
+  Widget _buildChartCard(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      elevation: 0,
+      color: colorScheme.surfaceContainerLow,
+      child: Padding(
+        padding: EdgeInsets.all(AppConstants.paddingM.w),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(context, colorScheme),
+            SizedBox(height: AppConstants.paddingM.h),
+            _buildChart(context, colorScheme),
+            if (widget.weightData.isNotEmpty) ...[
+              SizedBox(height: AppConstants.paddingS.h),
+              _buildLegend(colorScheme),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, ColorScheme colorScheme) {
+    return Row(
+      children: [
+        Text(
+          '体重推移',
+          style: AppTextStyles.headline3.copyWith(
+            color: colorScheme.onSurface,
+          ),
+        ),
+        const Spacer(),
+        if (widget.onRefresh != null)
+          IconButton(
+            onPressed: widget.onRefresh,
+            icon: Icon(
+              Icons.refresh_rounded,
+              color: colorScheme.primary,
+              size: 20.w,
+            ),
+            tooltip: '更新',
+          ),
+      ],
+    );
+  }
+
+  Widget _buildChart(BuildContext context, ColorScheme colorScheme) {
+    final isSmallScreen = MediaQuery.of(context).size.width < 600;
+    final chartHeight = isSmallScreen ? 250.0 : 300.0;
+
+    return SizedBox(
+      height: chartHeight.h,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        child: _buildChartContent(context, colorScheme, isSmallScreen),
+      ),
+    );
+  }
+
+  Widget _buildChartContent(BuildContext context, ColorScheme colorScheme, bool isSmallScreen) {
+    if (widget.isLoading) {
+      return _buildLoadingState(colorScheme);
+    }
+    
+    if (widget.errorMessage != null) {
+      return _buildErrorState(widget.errorMessage!, colorScheme);
+    }
+    
+    if (widget.weightData.isEmpty) {
+      return _buildEmptyState(colorScheme);
+    }
+
+    return RepaintBoundary(
+      child: GestureDetector(
+        onTap: () => _announceChartData(context),
+        child: LineChart(
+          _buildLineChartData(colorScheme, isSmallScreen),
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.easeInOutCubic,
+        ),
+      ),
+    );
+  }
+
+  LineChartData _buildLineChartData(ColorScheme colorScheme, bool isSmallScreen) {
+    return LineChartData(
+      lineBarsData: [
+        _buildWeightLine(colorScheme),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildMovingAverageLine(colorScheme),
+      ],
+      
+      gridData: FlGridData(
+        show: !isSmallScreen,
+        drawHorizontalLine: true,
+        drawVerticalLine: false,
+        horizontalInterval: ChartUtils.getOptimalInterval(_cachedWeightSpots.length),
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: colorScheme.outline.withOpacity(0.3),
+          strokeWidth: 1,
+        ),
+      ),
+      
+      titlesData: FlTitlesData(
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: isSmallScreen ? 35.w : 40.w,
+            getTitlesWidget: (value, meta) => _buildYAxisTitle(value, meta, colorScheme),
+            interval: 1,
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 25.h,
+            getTitlesWidget: (value, meta) => _buildXAxisTitle(value, meta, colorScheme),
+            interval: math.max(1, (_cachedWeightSpots.length / 6).round()).toDouble(),
+          ),
+        ),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(
+          color: colorScheme.outline.withOpacity(0.3),
+          width: 1,
+        ),
+      ),
+      
+      lineTouchData: LineTouchData(
+        enabled: true,
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => colorScheme.surface,
+          tooltipBorder: BorderSide(color: colorScheme.outline),
+          getTooltipItems: _buildTooltipItems,
+          tooltipRoundedRadius: 8,
+        ),
+        getTouchedSpotIndicator: (barData, spotIndexes) => 
+            spotIndexes.map((index) => TouchedSpotIndicatorData(
+              FlLine(
+                color: colorScheme.primary,
+                strokeWidth: 2,
+                dashArray: [5, 5],
+              ),
+              FlDotData(
+                getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+                  radius: 6,
+                  color: colorScheme.primary,
+                  strokeWidth: 2,
+                  strokeColor: colorScheme.surface,
+                ),
+              ),
+            )).toList(),
+      ),
+      
+      minX: _cachedBounds.minX,
+      maxX: _cachedBounds.maxX,
+      minY: _cachedBounds.minY,
+      maxY: _cachedBounds.maxY,
+    );
+  }
+
+  LineChartBarData _buildWeightLine(ColorScheme colorScheme) {
+    return LineChartBarData(
+      spots: _cachedWeightSpots,
+      isCurved: true,
+      curveSmoothness: 0.3,
+      color: colorScheme.primary,
+      barWidth: 3,
+      
+      dotData: FlDotData(
+        show: _cachedWeightSpots.length <= 30, // データが少ない時のみドット表示
+        getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+          radius: 4,
+          color: colorScheme.primary,
+          strokeWidth: 2,
+          strokeColor: colorScheme.surface,
+        ),
+      ),
+      
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            colorScheme.primary.withOpacity(0.3),
+            colorScheme.primary.withOpacity(0.1),
+          ],
+        ),
+      ),
+    );
+  }
+
+  LineChartBarData _buildMovingAverageLine(ColorScheme colorScheme) {
+    return LineChartBarData(
+      spots: _cachedMovingAverageSpots,
+      isCurved: true,
+      curveSmoothness: 0.4,
+      color: colorScheme.secondary,
+      barWidth: 2,
+      dashArray: [5, 5],
+      dotData: const FlDotData(show: false),
+      belowBarData: BarAreaData(show: false),
+    );
+  }
+
+  Widget _buildYAxisTitle(double value, TitleMeta meta, ColorScheme colorScheme) {
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text(
+        '${value.toStringAsFixed(0)}kg',
+        style: AppTextStyles.caption.copyWith(
+          color: colorScheme.onSurface,
+          fontSize: 10.sp,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildXAxisTitle(double value, TitleMeta meta, ColorScheme colorScheme) {
+    final index = value.toInt();
+    if (index < 0 || index >= widget.weightData.length) {
+      return const SizedBox.shrink();
+    }
+
+    final date = widget.weightData[index].date;
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text(
+        ChartUtils.formatDateForAxis(date, widget.weightData.length),
+        style: AppTextStyles.caption.copyWith(
+          color: colorScheme.onSurface,
+          fontSize: 9.sp,
+        ),
+      ),
+    );
+  }
+
+  List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots) {
+    return touchedSpots.map((barSpot) {
+      final flSpot = barSpot;
+      final index = flSpot.x.toInt();
+      
+      if (index >= 0 && index < widget.weightData.length) {
+        final data = widget.weightData[index];
+        final isMovingAverage = barSpot.barIndex == 1;
+        
+        return LineTooltipItem(
+          '${data.date.month}/${data.date.day}\n'
+          '${isMovingAverage ? "平均: " : "体重: "}'
+          '${flSpot.y.toStringAsFixed(1)}kg',
+          TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 12.sp,
+          ),
+        );
+      }
+      
+      return LineTooltipItem('', const TextStyle());
+    }).toList();
+  }
+
+  Widget _buildLegend(ColorScheme colorScheme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildLegendItem('実測値', colorScheme.primary, false),
+        SizedBox(width: AppConstants.paddingM.w),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildLegendItem('7日平均', colorScheme.secondary, true),
+      ],
+    );
+  }
+
+  Widget _buildLegendItem(String label, Color color, bool isDashed) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 20.w,
+          height: 3.h,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(1.5.r),
+          ),
+          child: isDashed ? CustomPaint(
+            painter: DashedLinePainter(color: color),
+          ) : null,
+        ),
+        SizedBox(width: 4.w),
+        Text(
+          label,
+          style: AppTextStyles.caption.copyWith(
+            color: color,
+            fontSize: 11.sp,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLoadingState(ColorScheme colorScheme) {
+    return Container(
+      alignment: Alignment.center,
+      child: CircularProgressIndicator(
+        color: colorScheme.primary,
+        strokeWidth: 2.w,
+      ),
+    );
+  }
+
+  Widget _buildErrorState(String error, ColorScheme colorScheme) {
+    return Container(
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline_rounded,
+            size: 48.w,
+            color: colorScheme.error,
+          ),
+          SizedBox(height: AppConstants.paddingS.h),
+          Text(
+            'グラフの表示中にエラーが発生しました',
+            style: AppTextStyles.body2.copyWith(
+              color: colorScheme.error,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(ColorScheme colorScheme) {
+    return Container(
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.show_chart_rounded,
+            size: 48.w,
+            color: colorScheme.outline,
+          ),
+          SizedBox(height: AppConstants.paddingS.h),
+          Text(
+            '体重データがありません',
+            style: AppTextStyles.body2.copyWith(
+              color: colorScheme.outline,
+            ),
+          ),
+          SizedBox(height: AppConstants.paddingS.h),
+          Text(
+            'HealthKitから体重データを取得するか、\n手動で記録してください',
+            style: AppTextStyles.caption.copyWith(
+              color: colorScheme.outline,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _announceChartData(BuildContext context) {
+    if (widget.weightData.isEmpty) {
+      SystemSound.play(SystemSoundType.click);
+      return;
+    }
+
+    final trend = ChartUtils.analyzeWeightTrend(widget.weightData);
+    final latestWeight = widget.weightData.last.weight;
+
+    // 簡易的なフィードバック
+    SystemSound.play(SystemSoundType.click);
+    
+    // 必要に応じて、ScaffoldMessengerでスナックバーを表示
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('最新体重: ${latestWeight.toStringAsFixed(1)}kg (${trend.displayName})'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}
+
+/// 破線描画用のカスタムペインター
+class DashedLinePainter extends CustomPainter {
+  final Color color;
+
+  DashedLinePainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+
+    final dashWidth = 3.0;
+    final dashSpace = 2.0;
+    double startX = 0;
+
+    while (startX < size.width) {
+      canvas.drawLine(
+        Offset(startX, size.height / 2),
+        Offset(math.min(startX + dashWidth, size.width), size.height / 2),
+        paint,
+      );
+      startX += dashWidth + dashSpace;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/presentation/widgets/weight_chart_widget_enhanced.dart
+++ b/lib/presentation/widgets/weight_chart_widget_enhanced.dart
@@ -1,0 +1,779 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import '../../core/themes/app_text_styles.dart';
+import '../../core/constants/app_constants.dart';
+import '../../core/services/health_service.dart';
+import '../../core/utils/chart_utils.dart';
+
+/// 拡張版体重グラフウィジェット（グラスモーフィズム・最新UIトレンド対応）
+class WeightChartWidgetEnhanced extends StatefulWidget {
+  final List<WeightData> weightData;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRefresh;
+
+  const WeightChartWidgetEnhanced({
+    super.key,
+    required this.weightData,
+    this.isLoading = false,
+    this.errorMessage,
+    this.onRefresh,
+  });
+
+  @override
+  State<WeightChartWidgetEnhanced> createState() => _WeightChartWidgetEnhancedState();
+}
+
+class _WeightChartWidgetEnhancedState extends State<WeightChartWidgetEnhanced> 
+    with TickerProviderStateMixin {
+  
+  late AnimationController _animationController;
+  late AnimationController _pulseController;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _fadeAnimation;
+  late Animation<double> _pulseAnimation;
+  
+  List<FlSpot>? _touchedSpots;
+  int? _selectedDataIndex;
+
+  late List<FlSpot> _cachedWeightSpots;
+  late List<FlSpot> _cachedMovingAverageSpots;
+  late ChartBounds _cachedBounds;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // アニメーションコントローラーの初期化
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
+    
+    _pulseController = AnimationController(
+      duration: const Duration(seconds: 2),
+      vsync: this,
+    )..repeat(reverse: true);
+    
+    _scaleAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.elasticOut,
+    ));
+    
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: const Interval(0.0, 0.6, curve: Curves.easeIn),
+    ));
+    
+    _pulseAnimation = Tween<double>(
+      begin: 1.0,
+      end: 1.1,
+    ).animate(CurvedAnimation(
+      parent: _pulseController,
+      curve: Curves.easeInOut,
+    ));
+    
+    _updateCachedData();
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(WeightChartWidgetEnhanced oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.weightData != widget.weightData) {
+      _updateCachedData();
+      _animationController.reset();
+      _animationController.forward();
+    }
+  }
+
+  void _updateCachedData() {
+    if (widget.weightData.isNotEmpty) {
+      final processedData = ChartUtils.downsampleData(widget.weightData, 90);
+      _cachedWeightSpots = ChartUtils.validateChartData(
+        ChartUtils.convertToFlSpots(processedData)
+      );
+      _cachedMovingAverageSpots = ChartUtils.validateChartData(
+        ChartUtils.calculateMovingAverage(processedData, 7)
+      );
+      _cachedBounds = ChartUtils.calculateSafeBounds(
+        [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
+        padding: 2.0,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    
+    return AnimatedBuilder(
+      animation: Listenable.merge([_animationController, _pulseController]),
+      builder: (context, child) {
+        return Transform.scale(
+          scale: 0.95 + (0.05 * _scaleAnimation.value),
+          child: Opacity(
+            opacity: _fadeAnimation.value,
+            child: _buildGlassmorphicCard(context, colorScheme),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildGlassmorphicCard(BuildContext context, ColorScheme colorScheme) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24.r),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            colorScheme.primary.withOpacity(0.1),
+            colorScheme.secondary.withOpacity(0.05),
+          ],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withOpacity(0.2),
+            blurRadius: 20.r,
+            offset: Offset(0, 10.h),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(24.r),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(24.r),
+              border: Border.all(
+                color: colorScheme.primary.withOpacity(0.2),
+                width: 1.5,
+              ),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Colors.white.withOpacity(0.1),
+                  Colors.white.withOpacity(0.05),
+                ],
+              ),
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(AppConstants.paddingL.w),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildEnhancedHeader(context, colorScheme),
+                  SizedBox(height: AppConstants.paddingM.h),
+                  _buildChart(context, colorScheme),
+                  if (widget.weightData.isNotEmpty) ...[
+                    SizedBox(height: AppConstants.paddingM.h),
+                    _buildEnhancedStats(colorScheme),
+                    SizedBox(height: AppConstants.paddingS.h),
+                    _buildModernLegend(colorScheme),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEnhancedHeader(BuildContext context, ColorScheme colorScheme) {
+    final latestWeight = widget.weightData.isNotEmpty ? widget.weightData.last.weight : 0.0;
+    final previousWeight = widget.weightData.length > 1 ? widget.weightData[widget.weightData.length - 2].weight : latestWeight;
+    final weightChange = latestWeight - previousWeight;
+    
+    return Row(
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '体重推移',
+              style: AppTextStyles.headline2.copyWith(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            SizedBox(height: 4.h),
+            Row(
+              children: [
+                Text(
+                  '${latestWeight.toStringAsFixed(1)}',
+                  style: AppTextStyles.headline1.copyWith(
+                    color: colorScheme.primary,
+                    fontSize: 36.sp,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                SizedBox(width: 8.w),
+                Text(
+                  'kg',
+                  style: AppTextStyles.body1.copyWith(
+                    color: colorScheme.primary.withOpacity(0.7),
+                  ),
+                ),
+                SizedBox(width: 16.w),
+                _buildTrendIndicator(weightChange, colorScheme),
+              ],
+            ),
+          ],
+        ),
+        const Spacer(),
+        if (widget.onRefresh != null)
+          Container(
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                colors: [
+                  colorScheme.primary.withOpacity(0.2),
+                  colorScheme.secondary.withOpacity(0.1),
+                ],
+              ),
+            ),
+            child: IconButton(
+              onPressed: widget.onRefresh,
+              icon: Icon(
+                Icons.refresh_rounded,
+                color: colorScheme.primary,
+                size: 24.w,
+              ),
+              tooltip: '更新',
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTrendIndicator(double change, ColorScheme colorScheme) {
+    final isUp = change > 0;
+    final color = isUp ? Colors.red : Colors.green;
+    
+    return AnimatedBuilder(
+      animation: _pulseAnimation,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _pulseAnimation.value,
+          child: Container(
+            padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(12.r),
+              border: Border.all(color: color.withOpacity(0.3)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  isUp ? Icons.trending_up : Icons.trending_down,
+                  color: color,
+                  size: 16.w,
+                ),
+                SizedBox(width: 4.w),
+                Text(
+                  '${change.abs().toStringAsFixed(1)}kg',
+                  style: AppTextStyles.caption.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildChart(BuildContext context, ColorScheme colorScheme) {
+    final chartHeight = 280.0.h;
+
+    return SizedBox(
+      height: chartHeight,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 500),
+        child: _buildChartContent(context, colorScheme),
+      ),
+    );
+  }
+
+  Widget _buildChartContent(BuildContext context, ColorScheme colorScheme) {
+    if (widget.isLoading) {
+      return _buildModernLoadingState(colorScheme);
+    }
+    
+    if (widget.errorMessage != null) {
+      return _buildModernErrorState(widget.errorMessage!, colorScheme);
+    }
+    
+    if (widget.weightData.isEmpty) {
+      return _buildModernEmptyState(colorScheme);
+    }
+
+    return RepaintBoundary(
+      child: GestureDetector(
+        onTapDown: (details) => _handleChartTouch(details, context),
+        child: LineChart(
+          _buildEnhancedLineChartData(colorScheme),
+          duration: const Duration(milliseconds: 800),
+          curve: Curves.easeInOutCubic,
+        ),
+      ),
+    );
+  }
+
+  void _handleChartTouch(TapDownDetails details, BuildContext context) {
+    // タッチ位置に基づいてデータポイントを特定
+    setState(() {
+      _selectedDataIndex = (_selectedDataIndex == null) ? 0 : null;
+    });
+    
+    HapticFeedback.lightImpact();
+  }
+
+  LineChartData _buildEnhancedLineChartData(ColorScheme colorScheme) {
+    return LineChartData(
+      lineBarsData: [
+        _buildEnhancedWeightLine(colorScheme),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildEnhancedMovingAverageLine(colorScheme),
+      ],
+      
+      gridData: FlGridData(
+        show: true,
+        drawHorizontalLine: true,
+        drawVerticalLine: false,
+        horizontalInterval: 2,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: colorScheme.outline.withOpacity(0.1),
+          strokeWidth: 1,
+          dashArray: [5, 5],
+        ),
+      ),
+      
+      titlesData: FlTitlesData(
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 45.w,
+            getTitlesWidget: (value, meta) => _buildModernYAxisTitle(value, meta, colorScheme),
+            interval: 2,
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 30.h,
+            getTitlesWidget: (value, meta) => _buildModernXAxisTitle(value, meta, colorScheme),
+            interval: math.max(1, (_cachedWeightSpots.length / 5).round()).toDouble(),
+          ),
+        ),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      
+      borderData: FlBorderData(show: false),
+      
+      lineTouchData: LineTouchData(
+        enabled: true,
+        handleBuiltInTouches: true,
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => colorScheme.surface.withOpacity(0.9),
+          tooltipBorder: BorderSide(
+            color: colorScheme.primary.withOpacity(0.3),
+            width: 1,
+          ),
+          getTooltipItems: _buildEnhancedTooltipItems,
+          tooltipRoundedRadius: 16.r,
+          tooltipPadding: EdgeInsets.all(12.w),
+        ),
+        getTouchedSpotIndicator: (barData, spotIndexes) => 
+            spotIndexes.map((index) => TouchedSpotIndicatorData(
+              FlLine(
+                color: colorScheme.primary,
+                strokeWidth: 3,
+                dashArray: [8, 4],
+              ),
+              FlDotData(
+                getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+                  radius: 8,
+                  color: colorScheme.primary,
+                  strokeWidth: 3,
+                  strokeColor: colorScheme.surface,
+                ),
+              ),
+            )).toList(),
+      ),
+      
+      minX: _cachedBounds.minX,
+      maxX: _cachedBounds.maxX,
+      minY: _cachedBounds.minY,
+      maxY: _cachedBounds.maxY,
+      
+      backgroundColor: Colors.transparent,
+    );
+  }
+
+  LineChartBarData _buildEnhancedWeightLine(ColorScheme colorScheme) {
+    return LineChartBarData(
+      spots: _cachedWeightSpots,
+      isCurved: true,
+      curveSmoothness: 0.4,
+      barWidth: 4,
+      isStrokeCapRound: true,
+      
+      gradient: LinearGradient(
+        colors: [
+          colorScheme.primary,
+          colorScheme.secondary,
+        ],
+        stops: const [0.0, 1.0],
+      ),
+      
+      dotData: FlDotData(
+        show: true,
+        getDotPainter: (spot, percent, barData, index) {
+          final isSelected = _selectedDataIndex == index;
+          return FlDotCirclePainter(
+            radius: isSelected ? 8 : 5,
+            color: colorScheme.primary,
+            strokeWidth: 2,
+            strokeColor: colorScheme.surface,
+          );
+        },
+      ),
+      
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            colorScheme.primary.withOpacity(0.3),
+            colorScheme.primary.withOpacity(0.0),
+          ],
+          stops: const [0.0, 1.0],
+        ),
+      ),
+      
+      shadow: Shadow(
+        color: colorScheme.primary.withOpacity(0.3),
+        blurRadius: 8,
+        offset: const Offset(0, 4),
+      ),
+    );
+  }
+
+  LineChartBarData _buildEnhancedMovingAverageLine(ColorScheme colorScheme) {
+    return LineChartBarData(
+      spots: _cachedMovingAverageSpots,
+      isCurved: true,
+      curveSmoothness: 0.5,
+      barWidth: 2,
+      isStrokeCapRound: true,
+      
+      color: colorScheme.tertiary.withOpacity(0.7),
+      dashArray: [8, 4],
+      
+      dotData: const FlDotData(show: false),
+      belowBarData: BarAreaData(show: false),
+    );
+  }
+
+  Widget _buildModernYAxisTitle(double value, TitleMeta meta, ColorScheme colorScheme) {
+    return Container(
+      margin: EdgeInsets.only(right: 8.w),
+      child: Text(
+        '${value.toStringAsFixed(0)}',
+        style: AppTextStyles.caption.copyWith(
+          color: colorScheme.onSurface.withOpacity(0.5),
+          fontSize: 11.sp,
+        ),
+        textAlign: TextAlign.right,
+      ),
+    );
+  }
+
+  Widget _buildModernXAxisTitle(double value, TitleMeta meta, ColorScheme colorScheme) {
+    final index = value.toInt();
+    if (index < 0 || index >= widget.weightData.length) {
+      return const SizedBox.shrink();
+    }
+
+    final date = widget.weightData[index].date;
+    return Transform.rotate(
+      angle: -0.5,
+      child: Text(
+        '${date.month}/${date.day}',
+        style: AppTextStyles.caption.copyWith(
+          color: colorScheme.onSurface.withOpacity(0.5),
+          fontSize: 10.sp,
+        ),
+      ),
+    );
+  }
+
+  List<LineTooltipItem> _buildEnhancedTooltipItems(List<LineBarSpot> touchedSpots) {
+    return touchedSpots.map((barSpot) {
+      final flSpot = barSpot;
+      final index = flSpot.x.toInt();
+      
+      if (index >= 0 && index < widget.weightData.length) {
+        final data = widget.weightData[index];
+        final isMovingAverage = barSpot.barIndex == 1;
+        
+        return LineTooltipItem(
+          '${data.date.month}月${data.date.day}日\n'
+          '${isMovingAverage ? "平均 " : ""}'
+          '${flSpot.y.toStringAsFixed(1)} kg',
+          TextStyle(
+            color: Theme.of(context).colorScheme.onSurface,
+            fontWeight: FontWeight.bold,
+            fontSize: 13.sp,
+          ),
+        );
+      }
+      
+      return LineTooltipItem('', const TextStyle());
+    }).toList();
+  }
+
+  Widget _buildEnhancedStats(ColorScheme colorScheme) {
+    if (widget.weightData.isEmpty) return const SizedBox.shrink();
+    
+    final trend = ChartUtils.analyzeWeightTrend(widget.weightData);
+    final minWeight = _cachedWeightSpots.map((s) => s.y).reduce(math.min);
+    final maxWeight = _cachedWeightSpots.map((s) => s.y).reduce(math.max);
+    final avgWeight = _cachedWeightSpots.map((s) => s.y).reduce((a, b) => a + b) / _cachedWeightSpots.length;
+    
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primary.withOpacity(0.05),
+            colorScheme.secondary.withOpacity(0.03),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(16.r),
+        border: Border.all(
+          color: colorScheme.primary.withOpacity(0.1),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _buildStatItem('最低', minWeight, Icons.arrow_downward, Colors.blue, colorScheme),
+          _buildStatItem('平均', avgWeight, Icons.remove, colorScheme.primary, colorScheme),
+          _buildStatItem('最高', maxWeight, Icons.arrow_upward, Colors.orange, colorScheme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatItem(String label, double value, IconData icon, Color color, ColorScheme colorScheme) {
+    return Column(
+      children: [
+        Icon(icon, color: color, size: 20.w),
+        SizedBox(height: 4.h),
+        Text(
+          label,
+          style: AppTextStyles.caption.copyWith(
+            color: colorScheme.onSurface.withOpacity(0.6),
+          ),
+        ),
+        Text(
+          '${value.toStringAsFixed(1)}kg',
+          style: AppTextStyles.body1.copyWith(
+            color: color,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModernLegend(ColorScheme colorScheme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildModernLegendItem('実測値', colorScheme.primary, false),
+        SizedBox(width: AppConstants.paddingL.w),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildModernLegendItem('7日平均', colorScheme.tertiary, true),
+      ],
+    );
+  }
+
+  Widget _buildModernLegendItem(String label, Color color, bool isDashed) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(20.r),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 24.w,
+            height: 3.h,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(2.r),
+            ),
+          ),
+          SizedBox(width: 8.w),
+          Text(
+            label,
+            style: AppTextStyles.caption.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+              fontSize: 12.sp,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModernLoadingState(ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 60.w,
+            height: 60.w,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                colors: [
+                  colorScheme.primary.withOpacity(0.3),
+                  colorScheme.secondary.withOpacity(0.3),
+                ],
+              ),
+            ),
+            child: Center(
+              child: CircularProgressIndicator(
+                color: colorScheme.primary,
+                strokeWidth: 3.w,
+              ),
+            ),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データを読み込んでいます...',
+            style: AppTextStyles.body2.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModernErrorState(String error, ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: EdgeInsets.all(16.w),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: colorScheme.error.withOpacity(0.1),
+            ),
+            child: Icon(
+              Icons.error_outline_rounded,
+              size: 48.w,
+              color: colorScheme.error,
+            ),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データの読み込みに失敗しました',
+            style: AppTextStyles.body1.copyWith(
+              color: colorScheme.error,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            'タップして再試行',
+            style: AppTextStyles.caption.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModernEmptyState(ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: EdgeInsets.all(20.w),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                colors: [
+                  colorScheme.primary.withOpacity(0.1),
+                  colorScheme.secondary.withOpacity(0.05),
+                ],
+              ),
+            ),
+            child: Icon(
+              Icons.insights_rounded,
+              size: 56.w,
+              color: colorScheme.primary.withOpacity(0.5),
+            ),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'まだデータがありません',
+            style: AppTextStyles.headline3.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.8),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            '体重を記録してグラフを表示しましょう',
+            style: AppTextStyles.body2.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/weight_chart_widget_health.dart
+++ b/lib/presentation/widgets/weight_chart_widget_health.dart
@@ -95,29 +95,11 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
     
-    return Container(
-      decoration: BoxDecoration(
-        color: isDark ? Colors.grey[900] : Colors.white,
-        borderRadius: BorderRadius.circular(20.r),
-        boxShadow: [
-          BoxShadow(
-            color: isDark 
-              ? Colors.black.withOpacity(0.3)
-              : Colors.grey.withOpacity(0.08),
-            blurRadius: 24.r,
-            offset: Offset(0, 8.h),
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: EdgeInsets.zero, // パディングを削除してカード幅いっぱいに
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildChart(context, isDark),
-          ],
-        ),
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildChart(context, isDark),
+      ],
     );
   }
 
@@ -139,7 +121,7 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
       animation: _chartAnimation,
       builder: (context, child) {
         return Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+          padding: EdgeInsets.symmetric(horizontal: 0.w, vertical: 8.h),
           child: LineChart(
             _buildLineChartData(isDark),
             duration: const Duration(milliseconds: 0),

--- a/lib/presentation/widgets/weight_chart_widget_health.dart
+++ b/lib/presentation/widgets/weight_chart_widget_health.dart
@@ -121,7 +121,7 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
       animation: _chartAnimation,
       builder: (context, child) {
         return Padding(
-          padding: EdgeInsets.symmetric(horizontal: 0.w, vertical: 8.h),
+          padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 8.h, bottom: 0.h),
           child: LineChart(
             _buildLineChartData(isDark),
             duration: const Duration(milliseconds: 0),

--- a/lib/presentation/widgets/weight_chart_widget_health.dart
+++ b/lib/presentation/widgets/weight_chart_widget_health.dart
@@ -1,0 +1,434 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'dart:math' as math;
+
+import '../../core/themes/app_text_styles.dart';
+import '../../core/constants/app_constants.dart';
+import '../../core/services/health_service.dart';
+import '../../core/utils/chart_utils.dart';
+
+/// 身体・活動画面用の体重グラフウィジェット
+class WeightChartWidgetHealth extends StatefulWidget {
+  final List<WeightData> weightData;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRefresh;
+
+  const WeightChartWidgetHealth({
+    super.key,
+    required this.weightData,
+    this.isLoading = false,
+    this.errorMessage,
+    this.onRefresh,
+  });
+
+  @override
+  State<WeightChartWidgetHealth> createState() => _WeightChartWidgetHealthState();
+}
+
+class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth> 
+    with TickerProviderStateMixin {
+  
+  late AnimationController _animationController;
+  late Animation<double> _chartAnimation;
+  
+  int? _touchedIndex;
+
+  late List<FlSpot> _cachedWeightSpots;
+  late List<FlSpot> _cachedMovingAverageSpots;
+  late ChartBounds _cachedBounds;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    );
+    
+    _chartAnimation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeOutCubic,
+    );
+    
+    _updateCachedData();
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(WeightChartWidgetHealth oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.weightData != widget.weightData) {
+      _updateCachedData();
+      _animationController.reset();
+      _animationController.forward();
+    }
+  }
+
+  void _updateCachedData() {
+    if (widget.weightData.isNotEmpty) {
+      final processedData = ChartUtils.downsampleData(widget.weightData, 30);
+      _cachedWeightSpots = ChartUtils.validateChartData(
+        ChartUtils.convertToFlSpots(processedData)
+      );
+      _cachedMovingAverageSpots = ChartUtils.validateChartData(
+        ChartUtils.calculateMovingAverage(processedData, 7)
+      );
+      _cachedBounds = ChartUtils.calculateSafeBounds(
+        [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
+        padding: 2.0,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey[900] : Colors.white,
+        borderRadius: BorderRadius.circular(20.r),
+        boxShadow: [
+          BoxShadow(
+            color: isDark 
+              ? Colors.black.withOpacity(0.3)
+              : Colors.grey.withOpacity(0.08),
+            blurRadius: 24.r,
+            offset: Offset(0, 8.h),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: EdgeInsets.zero, // パディングを削除してカード幅いっぱいに
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildChart(context, isDark),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChart(BuildContext context, bool isDark) {
+    return SizedBox(
+      height: 240.h,
+      child: widget.isLoading
+        ? _buildLoadingState(isDark)
+        : widget.errorMessage != null
+          ? _buildErrorState(widget.errorMessage!, isDark)
+          : widget.weightData.isEmpty
+            ? _buildEmptyState(isDark)
+            : _buildChartContent(isDark),
+    );
+  }
+
+  Widget _buildChartContent(bool isDark) {
+    return AnimatedBuilder(
+      animation: _chartAnimation,
+      builder: (context, child) {
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+          child: LineChart(
+            _buildLineChartData(isDark),
+            duration: const Duration(milliseconds: 0),
+          ),
+        );
+      },
+    );
+  }
+
+  LineChartData _buildLineChartData(bool isDark) {
+    return LineChartData(
+      lineBarsData: [
+        _buildMainLine(isDark),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildAverageLine(isDark),
+      ],
+      
+      gridData: FlGridData(
+        show: true,
+        drawHorizontalLine: true,
+        drawVerticalLine: false,
+        horizontalInterval: 2,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: isDark 
+            ? Colors.grey[800]!.withOpacity(0.3)
+            : Colors.grey[200]!,
+          strokeWidth: 1,
+        ),
+      ),
+      
+      titlesData: FlTitlesData(
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 40.w,
+            getTitlesWidget: (value, meta) => _buildYAxisLabel(value, meta, isDark),
+            interval: 2,
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 30.h,
+            getTitlesWidget: (value, meta) => _buildXAxisLabel(value, meta, isDark),
+            interval: math.max(1, (_cachedWeightSpots.length / 6).round()).toDouble(),
+          ),
+        ),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      
+      borderData: FlBorderData(show: false),
+      
+      lineTouchData: LineTouchData(
+        enabled: true,
+        touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+          if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+            setState(() {
+              _touchedIndex = response.lineBarSpots!.first.x.toInt();
+            });
+            HapticFeedback.lightImpact();
+          } else {
+            setState(() {
+              _touchedIndex = null;
+            });
+          }
+        },
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => isDark 
+            ? Colors.grey[800]!
+            : Colors.white,
+          tooltipBorder: BorderSide(
+            color: isDark
+              ? Colors.grey[700]!
+              : Colors.grey[200]!,
+            width: 1,
+          ),
+          tooltipRoundedRadius: 12.r,
+          tooltipPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+          getTooltipItems: (touchedSpots) => _buildTooltipItems(touchedSpots, isDark),
+        ),
+        getTouchedSpotIndicator: (barData, spotIndexes) => 
+          spotIndexes.map((index) => TouchedSpotIndicatorData(
+            FlLine(color: Colors.transparent),
+            FlDotData(
+              show: true,
+              getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+                radius: 6,
+                color: const Color(0xFF6366F1),
+                strokeWidth: 2,
+                strokeColor: Colors.white,
+              ),
+            ),
+          )).toList(),
+      ),
+      
+      minX: _cachedBounds.minX,
+      maxX: _cachedBounds.maxX,
+      minY: _cachedBounds.minY,
+      maxY: _cachedBounds.maxY,
+      
+      backgroundColor: Colors.transparent,
+    );
+  }
+
+  LineChartBarData _buildMainLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedWeightSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.3,
+      barWidth: 3,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFF6366F1),
+      
+      dotData: FlDotData(
+        show: true,
+        getDotPainter: (spot, percent, barData, index) {
+          final isTouched = _touchedIndex == index;
+          return FlDotCirclePainter(
+            radius: isTouched ? 8 : 4,
+            color: const Color(0xFF6366F1),
+            strokeWidth: 2,
+            strokeColor: Colors.white,
+          );
+        },
+      ),
+      
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            const Color(0xFF6366F1).withOpacity(0.2),
+            const Color(0xFF6366F1).withOpacity(0.0),
+          ],
+        ),
+      ),
+    );
+  }
+
+  LineChartBarData _buildAverageLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedMovingAverageSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.4,
+      barWidth: 2,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFFF472B6).withOpacity(0.6),
+      dashArray: [6, 3],
+      
+      dotData: const FlDotData(show: false),
+      belowBarData: BarAreaData(show: false),
+    );
+  }
+
+  Widget _buildYAxisLabel(double value, TitleMeta meta, bool isDark) {
+    return Padding(
+      padding: EdgeInsets.only(right: 8.w),
+      child: Text(
+        value.toStringAsFixed(0),
+        style: TextStyle(
+          fontSize: 11.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+        textAlign: TextAlign.right,
+      ),
+    );
+  }
+
+  Widget _buildXAxisLabel(double value, TitleMeta meta, bool isDark) {
+    final index = value.toInt();
+    if (index < 0 || index >= widget.weightData.length) {
+      return const SizedBox.shrink();
+    }
+
+    final date = widget.weightData[index].date;
+    return Padding(
+      padding: EdgeInsets.only(top: 8.h),
+      child: Text(
+        '${date.month}/${date.day}',
+        style: TextStyle(
+          fontSize: 11.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+    );
+  }
+
+  List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots, bool isDark) {
+    return touchedSpots.map((barSpot) {
+      final index = barSpot.x.toInt();
+      
+      if (index >= 0 && index < widget.weightData.length) {
+        final data = widget.weightData[index];
+        final isAverage = barSpot.barIndex == 1;
+        
+        return LineTooltipItem(
+          isAverage ? '平均' : '${data.date.month}月${data.date.day}日',
+          TextStyle(
+            color: isDark ? Colors.grey[400] : Colors.grey[600],
+            fontSize: 11.sp,
+            fontWeight: FontWeight.w400,
+          ),
+          children: [
+            TextSpan(
+              text: '\n${barSpot.y.toStringAsFixed(1)} kg',
+              style: TextStyle(
+                color: isDark ? Colors.white : Colors.grey[900],
+                fontSize: 13.sp,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        );
+      }
+      
+      return LineTooltipItem('', const TextStyle());
+    }).toList();
+  }
+
+  Widget _buildLoadingState(bool isDark) {
+    return Center(
+      child: CircularProgressIndicator(
+        color: const Color(0xFF6366F1),
+        strokeWidth: 2.w,
+      ),
+    );
+  }
+
+  Widget _buildErrorState(String error, bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 48.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データの読み込みに失敗しました',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.show_chart,
+            size: 48.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データがありません',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -1,0 +1,433 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'dart:math' as math;
+
+import '../../core/themes/app_text_styles.dart';
+import '../../core/constants/app_constants.dart';
+import '../../core/services/health_service.dart';
+import '../../core/utils/chart_utils.dart';
+
+/// ホーム画面用のシンプルな体重グラフウィジェット
+class WeightChartWidgetHome extends StatefulWidget {
+  final List<WeightData> weightData;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRefresh;
+
+  const WeightChartWidgetHome({
+    super.key,
+    required this.weightData,
+    this.isLoading = false,
+    this.errorMessage,
+    this.onRefresh,
+  });
+
+  @override
+  State<WeightChartWidgetHome> createState() => _WeightChartWidgetHomeState();
+}
+
+class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome> 
+    with TickerProviderStateMixin {
+  
+  late AnimationController _animationController;
+  late Animation<double> _chartAnimation;
+  
+  int? _touchedIndex;
+
+  late List<FlSpot> _cachedWeightSpots;
+  late List<FlSpot> _cachedMovingAverageSpots;
+  late ChartBounds _cachedBounds;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 1000),
+      vsync: this,
+    );
+    
+    _chartAnimation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeOutCubic,
+    );
+    
+    _updateCachedData();
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(WeightChartWidgetHome oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.weightData != widget.weightData) {
+      _updateCachedData();
+      _animationController.reset();
+      _animationController.forward();
+    }
+  }
+
+  void _updateCachedData() {
+    if (widget.weightData.isNotEmpty) {
+      final processedData = ChartUtils.downsampleData(widget.weightData, 30);
+      _cachedWeightSpots = ChartUtils.validateChartData(
+        ChartUtils.convertToFlSpots(processedData)
+      );
+      _cachedMovingAverageSpots = ChartUtils.validateChartData(
+        ChartUtils.calculateMovingAverage(processedData, 7)
+      );
+      _cachedBounds = ChartUtils.calculateSafeBounds(
+        [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
+        padding: 2.0,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey[900] : Colors.white,
+        borderRadius: BorderRadius.circular(20.r),
+        boxShadow: [
+          BoxShadow(
+            color: isDark 
+              ? Colors.black.withOpacity(0.3)
+              : Colors.grey.withOpacity(0.08),
+            blurRadius: 24.r,
+            offset: Offset(0, 8.h),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 20.h),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildChart(context, colorScheme, isDark),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChart(BuildContext context, ColorScheme colorScheme, bool isDark) {
+    return SizedBox(
+      height: 180.h,
+      child: widget.isLoading
+        ? _buildLoadingState(isDark)
+        : widget.errorMessage != null
+          ? _buildErrorState(widget.errorMessage!, isDark)
+          : widget.weightData.isEmpty
+            ? _buildEmptyState(isDark)
+            : _buildChartContent(colorScheme, isDark),
+    );
+  }
+
+  Widget _buildChartContent(ColorScheme colorScheme, bool isDark) {
+    return AnimatedBuilder(
+      animation: _chartAnimation,
+      builder: (context, child) {
+        return LineChart(
+          _buildLineChartData(colorScheme, isDark),
+          duration: const Duration(milliseconds: 0),
+        );
+      },
+    );
+  }
+
+  LineChartData _buildLineChartData(ColorScheme colorScheme, bool isDark) {
+    return LineChartData(
+      lineBarsData: [
+        _buildMainLine(isDark),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildAverageLine(isDark),
+      ],
+      
+      gridData: FlGridData(
+        show: true,
+        drawHorizontalLine: true,
+        drawVerticalLine: false,
+        horizontalInterval: 2,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: isDark 
+            ? Colors.grey[800]!.withOpacity(0.3)
+            : Colors.grey[200]!,
+          strokeWidth: 1,
+        ),
+      ),
+      
+      titlesData: FlTitlesData(
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 35.w,
+            getTitlesWidget: (value, meta) => _buildYAxisLabel(value, meta, isDark),
+            interval: 2,
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 30.h,
+            getTitlesWidget: (value, meta) => _buildXAxisLabel(value, meta, isDark),
+            interval: math.max(1, (_cachedWeightSpots.length / 5).round()).toDouble(),
+          ),
+        ),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      
+      borderData: FlBorderData(show: false),
+      
+      lineTouchData: LineTouchData(
+        enabled: true,
+        touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+          if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+            setState(() {
+              _touchedIndex = response.lineBarSpots!.first.x.toInt();
+            });
+            HapticFeedback.lightImpact();
+          } else {
+            setState(() {
+              _touchedIndex = null;
+            });
+          }
+        },
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => isDark 
+            ? Colors.grey[800]!
+            : Colors.white,
+          tooltipBorder: BorderSide(
+            color: isDark
+              ? Colors.grey[700]!
+              : Colors.grey[200]!,
+            width: 1,
+          ),
+          tooltipRoundedRadius: 12.r,
+          tooltipPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+          getTooltipItems: (touchedSpots) => _buildTooltipItems(touchedSpots, isDark),
+        ),
+        getTouchedSpotIndicator: (barData, spotIndexes) => 
+          spotIndexes.map((index) => TouchedSpotIndicatorData(
+            FlLine(color: Colors.transparent),
+            FlDotData(
+              show: true,
+              getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+                radius: 6,
+                color: const Color(0xFF6366F1),
+                strokeWidth: 2,
+                strokeColor: Colors.white,
+              ),
+            ),
+          )).toList(),
+      ),
+      
+      minX: _cachedBounds.minX,
+      maxX: _cachedBounds.maxX,
+      minY: _cachedBounds.minY,
+      maxY: _cachedBounds.maxY,
+      
+      backgroundColor: Colors.transparent,
+    );
+  }
+
+  LineChartBarData _buildMainLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedWeightSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final index = entry.key;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.3,
+      barWidth: 3,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFF6366F1),
+      
+      dotData: FlDotData(
+        show: true,
+        getDotPainter: (spot, percent, barData, index) {
+          final isTouched = _touchedIndex == index;
+          return FlDotCirclePainter(
+            radius: isTouched ? 8 : 4,
+            color: const Color(0xFF6366F1),
+            strokeWidth: 2,
+            strokeColor: Colors.white,
+          );
+        },
+      ),
+      
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            const Color(0xFF6366F1).withOpacity(0.2),
+            const Color(0xFF6366F1).withOpacity(0.0),
+          ],
+        ),
+      ),
+    );
+  }
+
+  LineChartBarData _buildAverageLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedMovingAverageSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.4,
+      barWidth: 2,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFFF472B6).withOpacity(0.6),
+      dashArray: [6, 3],
+      
+      dotData: const FlDotData(show: false),
+      belowBarData: BarAreaData(show: false),
+    );
+  }
+
+  Widget _buildYAxisLabel(double value, TitleMeta meta, bool isDark) {
+    return Padding(
+      padding: EdgeInsets.only(right: 4.w),
+      child: Text(
+        value.toStringAsFixed(0),
+        style: TextStyle(
+          fontSize: 10.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+        textAlign: TextAlign.right,
+      ),
+    );
+  }
+
+  Widget _buildXAxisLabel(double value, TitleMeta meta, bool isDark) {
+    final index = value.toInt();
+    if (index < 0 || index >= widget.weightData.length) {
+      return const SizedBox.shrink();
+    }
+
+    final date = widget.weightData[index].date;
+    return Padding(
+      padding: EdgeInsets.only(top: 6.h),
+      child: Text(
+        '${date.month}/${date.day}',
+        style: TextStyle(
+          fontSize: 10.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+    );
+  }
+
+  List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots, bool isDark) {
+    return touchedSpots.map((barSpot) {
+      final index = barSpot.x.toInt();
+      
+      if (index >= 0 && index < widget.weightData.length) {
+        final data = widget.weightData[index];
+        final isAverage = barSpot.barIndex == 1;
+        
+        return LineTooltipItem(
+          isAverage ? '平均' : '${data.date.month}月${data.date.day}日',
+          TextStyle(
+            color: isDark ? Colors.grey[400] : Colors.grey[600],
+            fontSize: 10.sp,
+            fontWeight: FontWeight.w400,
+          ),
+          children: [
+            TextSpan(
+              text: '\n${barSpot.y.toStringAsFixed(1)} kg',
+              style: TextStyle(
+                color: isDark ? Colors.white : Colors.grey[900],
+                fontSize: 12.sp,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        );
+      }
+      
+      return LineTooltipItem('', const TextStyle());
+    }).toList();
+  }
+
+  Widget _buildLoadingState(bool isDark) {
+    return Center(
+      child: CircularProgressIndicator(
+        color: const Color(0xFF6366F1),
+        strokeWidth: 2.w,
+      ),
+    );
+  }
+
+  Widget _buildErrorState(String error, bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 32.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            'データの読み込みに失敗しました',
+            style: TextStyle(
+              fontSize: 12.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.show_chart,
+            size: 32.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            'データがありません',
+            style: TextStyle(
+              fontSize: 12.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -111,7 +111,7 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
         ],
       ),
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 0.w, vertical: 20.h),
+        padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 20.h, bottom: 20.h),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -111,7 +111,7 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
         ],
       ),
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 20.h),
+        padding: EdgeInsets.symmetric(horizontal: 0.w, vertical: 20.h),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -111,7 +111,7 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
         ],
       ),
       child: Padding(
-        padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 20.h, bottom: 20.h),
+        padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 20.h, bottom: 5.h),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/presentation/widgets/weight_chart_widget_modern.dart
+++ b/lib/presentation/widgets/weight_chart_widget_modern.dart
@@ -1,0 +1,800 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import '../../core/themes/app_text_styles.dart';
+import '../../core/constants/app_constants.dart';
+import '../../core/services/health_service.dart';
+import '../../core/utils/chart_utils.dart';
+
+/// モダンダッシュボード風体重グラフウィジェット
+class WeightChartWidgetModern extends StatefulWidget {
+  final List<WeightData> weightData;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRefresh;
+
+  const WeightChartWidgetModern({
+    super.key,
+    required this.weightData,
+    this.isLoading = false,
+    this.errorMessage,
+    this.onRefresh,
+  });
+
+  @override
+  State<WeightChartWidgetModern> createState() => _WeightChartWidgetModernState();
+}
+
+class _WeightChartWidgetModernState extends State<WeightChartWidgetModern> 
+    with TickerProviderStateMixin {
+  
+  late AnimationController _animationController;
+  late AnimationController _dotAnimationController;
+  late Animation<double> _chartAnimation;
+  late Animation<double> _fadeAnimation;
+  
+  int? _touchedIndex;
+  double? _touchedValue;
+
+  late List<FlSpot> _cachedWeightSpots;
+  late List<FlSpot> _cachedMovingAverageSpots;
+  late ChartBounds _cachedBounds;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    );
+    
+    _dotAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 600),
+      vsync: this,
+    );
+    
+    _chartAnimation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeOutCubic,
+    );
+    
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: const Interval(0.0, 0.5, curve: Curves.easeIn),
+    ));
+    
+    _updateCachedData();
+    _animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    _dotAnimationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(WeightChartWidgetModern oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.weightData != widget.weightData) {
+      _updateCachedData();
+      _animationController.reset();
+      _animationController.forward();
+    }
+  }
+
+  void _updateCachedData() {
+    if (widget.weightData.isNotEmpty) {
+      final processedData = ChartUtils.downsampleData(widget.weightData, 30);
+      _cachedWeightSpots = ChartUtils.validateChartData(
+        ChartUtils.convertToFlSpots(processedData)
+      );
+      _cachedMovingAverageSpots = ChartUtils.validateChartData(
+        ChartUtils.calculateMovingAverage(processedData, 7)
+      );
+      _cachedBounds = ChartUtils.calculateSafeBounds(
+        [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
+        padding: 2.0,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    
+    return AnimatedBuilder(
+      animation: _fadeAnimation,
+      builder: (context, child) {
+        return Opacity(
+          opacity: _fadeAnimation.value,
+          child: Container(
+            decoration: BoxDecoration(
+              color: isDark ? Colors.grey[900] : Colors.white,
+              borderRadius: BorderRadius.circular(20.r),
+              boxShadow: [
+                BoxShadow(
+                  color: isDark 
+                    ? Colors.black.withOpacity(0.3)
+                    : Colors.grey.withOpacity(0.08),
+                  blurRadius: 24.r,
+                  offset: Offset(0, 8.h),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(24.w),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildModernHeader(context, colorScheme, isDark),
+                  SizedBox(height: 32.h),
+                  _buildChart(context, colorScheme, isDark),
+                  if (widget.weightData.isNotEmpty) ...[
+                    SizedBox(height: 24.h),
+                    _buildProgressIndicators(colorScheme, isDark),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildModernHeader(BuildContext context, ColorScheme colorScheme, bool isDark) {
+    final latestWeight = widget.weightData.isNotEmpty ? widget.weightData.last.weight : 0.0;
+    final previousWeight = widget.weightData.length > 7 
+      ? widget.weightData[widget.weightData.length - 8].weight 
+      : latestWeight;
+    final weeklyChange = latestWeight - previousWeight;
+    final percentageChange = previousWeight != 0 
+      ? ((weeklyChange / previousWeight) * 100).abs() 
+      : 0.0;
+    
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '体重管理',
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  fontWeight: FontWeight.w500,
+                  color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  letterSpacing: 0.5,
+                ),
+              ),
+              SizedBox(height: 8.h),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    latestWeight.toStringAsFixed(1),
+                    style: TextStyle(
+                      fontSize: 32.sp,
+                      fontWeight: FontWeight.w700,
+                      color: isDark ? Colors.white : Colors.grey[900],
+                      letterSpacing: -1,
+                    ),
+                  ),
+                  SizedBox(width: 4.w),
+                  Text(
+                    'kg',
+                    style: TextStyle(
+                      fontSize: 18.sp,
+                      fontWeight: FontWeight.w400,
+                      color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 12.h),
+              _buildChangeIndicator(weeklyChange, percentageChange, isDark),
+            ],
+          ),
+        ),
+        _buildActionButtons(colorScheme, isDark),
+      ],
+    );
+  }
+
+  Widget _buildChangeIndicator(double change, double percentage, bool isDark) {
+    final isPositive = change >= 0;
+    final color = isPositive ? const Color(0xFFFF6B6B) : const Color(0xFF4ECDC4);
+    final bgColor = color.withOpacity(0.1);
+    
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(8.r),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isPositive ? Icons.trending_up : Icons.trending_down,
+            color: color,
+            size: 16.w,
+          ),
+          SizedBox(width: 4.w),
+          Text(
+            '${change.abs().toStringAsFixed(1)}kg (${percentage.toStringAsFixed(1)}%)',
+            style: TextStyle(
+              fontSize: 13.sp,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+          SizedBox(width: 8.w),
+          Text(
+            '今週',
+            style: TextStyle(
+              fontSize: 12.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(ColorScheme colorScheme, bool isDark) {
+    return Row(
+      children: [
+        _buildIconButton(
+          Icons.calendar_today_outlined,
+          () => _showDateRangePicker(context),
+          isDark,
+        ),
+        SizedBox(width: 8.w),
+        _buildIconButton(
+          Icons.download_outlined,
+          () => _exportData(),
+          isDark,
+        ),
+        if (widget.onRefresh != null) ...[
+          SizedBox(width: 8.w),
+          _buildIconButton(
+            Icons.refresh,
+            widget.onRefresh!,
+            isDark,
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildIconButton(IconData icon, VoidCallback onTap, bool isDark) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12.r),
+      child: Container(
+        padding: EdgeInsets.all(10.w),
+        decoration: BoxDecoration(
+          color: isDark ? Colors.grey[800] : Colors.grey[100],
+          borderRadius: BorderRadius.circular(12.r),
+        ),
+        child: Icon(
+          icon,
+          size: 20.w,
+          color: isDark ? Colors.grey[300] : Colors.grey[700],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChart(BuildContext context, ColorScheme colorScheme, bool isDark) {
+    return SizedBox(
+      height: 240.h,
+      child: widget.isLoading
+        ? _buildLoadingState(isDark)
+        : widget.errorMessage != null
+          ? _buildErrorState(widget.errorMessage!, isDark)
+          : widget.weightData.isEmpty
+            ? _buildEmptyState(isDark)
+            : _buildChartContent(colorScheme, isDark),
+    );
+  }
+
+  Widget _buildChartContent(ColorScheme colorScheme, bool isDark) {
+    return AnimatedBuilder(
+      animation: _chartAnimation,
+      builder: (context, child) {
+        return LineChart(
+          _buildLineChartData(colorScheme, isDark),
+          duration: const Duration(milliseconds: 0),
+        );
+      },
+    );
+  }
+
+  LineChartData _buildLineChartData(ColorScheme colorScheme, bool isDark) {
+    return LineChartData(
+      lineBarsData: [
+        _buildMainLine(isDark),
+        if (_cachedMovingAverageSpots.isNotEmpty)
+          _buildAverageLine(isDark),
+      ],
+      
+      gridData: FlGridData(
+        show: true,
+        drawHorizontalLine: true,
+        drawVerticalLine: false,
+        horizontalInterval: 2,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: isDark 
+            ? Colors.grey[800]!.withOpacity(0.3)
+            : Colors.grey[200]!,
+          strokeWidth: 1,
+        ),
+      ),
+      
+      titlesData: FlTitlesData(
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 40.w,
+            getTitlesWidget: (value, meta) => _buildYAxisLabel(value, meta, isDark),
+            interval: 2,
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 40.h,
+            getTitlesWidget: (value, meta) => _buildXAxisLabel(value, meta, isDark),
+            interval: math.max(1, (_cachedWeightSpots.length / 6).round()).toDouble(),
+          ),
+        ),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      
+      borderData: FlBorderData(show: false),
+      
+      lineTouchData: LineTouchData(
+        enabled: true,
+        touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+          if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+            setState(() {
+              _touchedIndex = response.lineBarSpots!.first.x.toInt();
+              _touchedValue = response.lineBarSpots!.first.y;
+            });
+            _dotAnimationController.forward(from: 0);
+            HapticFeedback.lightImpact();
+          } else {
+            setState(() {
+              _touchedIndex = null;
+              _touchedValue = null;
+            });
+          }
+        },
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => isDark 
+            ? Colors.grey[800]!
+            : Colors.white,
+          tooltipBorder: BorderSide(
+            color: isDark
+              ? Colors.grey[700]!
+              : Colors.grey[200]!,
+            width: 1,
+          ),
+          tooltipRoundedRadius: 12.r,
+          tooltipPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+          getTooltipItems: (touchedSpots) => _buildTooltipItems(touchedSpots, isDark),
+        ),
+        getTouchedSpotIndicator: (barData, spotIndexes) => 
+          spotIndexes.map((index) => TouchedSpotIndicatorData(
+            FlLine(color: Colors.transparent),
+            FlDotData(
+              show: true,
+              getDotPainter: (spot, percent, barData, index) => FlDotCirclePainter(
+                radius: 6,
+                color: const Color(0xFF6366F1),
+                strokeWidth: 2,
+                strokeColor: Colors.white,
+              ),
+            ),
+          )).toList(),
+      ),
+      
+      minX: _cachedBounds.minX,
+      maxX: _cachedBounds.maxX,
+      minY: _cachedBounds.minY,
+      maxY: _cachedBounds.maxY,
+      
+      backgroundColor: Colors.transparent,
+    );
+  }
+
+  LineChartBarData _buildMainLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedWeightSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final index = entry.key;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.3,
+      barWidth: 3,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFF6366F1),
+      
+      dotData: FlDotData(
+        show: true,
+        getDotPainter: (spot, percent, barData, index) {
+          final isTouched = _touchedIndex == index;
+          return FlDotCirclePainter(
+            radius: isTouched ? 8 : 4,
+            color: const Color(0xFF6366F1),
+            strokeWidth: 2,
+            strokeColor: Colors.white,
+          );
+        },
+      ),
+      
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            const Color(0xFF6366F1).withOpacity(0.2),
+            const Color(0xFF6366F1).withOpacity(0.0),
+          ],
+        ),
+      ),
+    );
+  }
+
+  LineChartBarData _buildAverageLine(bool isDark) {
+    return LineChartBarData(
+      spots: _cachedMovingAverageSpots.asMap().entries.map((entry) {
+        final progress = _chartAnimation.value;
+        final spot = entry.value;
+        final animatedY = spot.y * progress + (_cachedBounds.minY * (1 - progress));
+        return FlSpot(spot.x, animatedY);
+      }).toList(),
+      
+      isCurved: true,
+      curveSmoothness: 0.4,
+      barWidth: 2,
+      isStrokeCapRound: true,
+      
+      color: const Color(0xFFF472B6).withOpacity(0.6),
+      dashArray: [6, 3],
+      
+      dotData: const FlDotData(show: false),
+      belowBarData: BarAreaData(show: false),
+    );
+  }
+
+  Widget _buildYAxisLabel(double value, TitleMeta meta, bool isDark) {
+    return Padding(
+      padding: EdgeInsets.only(right: 8.w),
+      child: Text(
+        value.toStringAsFixed(0),
+        style: TextStyle(
+          fontSize: 11.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+        textAlign: TextAlign.right,
+      ),
+    );
+  }
+
+  Widget _buildXAxisLabel(double value, TitleMeta meta, bool isDark) {
+    final index = value.toInt();
+    if (index < 0 || index >= widget.weightData.length) {
+      return const SizedBox.shrink();
+    }
+
+    final date = widget.weightData[index].date;
+    return Padding(
+      padding: EdgeInsets.only(top: 8.h),
+      child: Text(
+        '${date.month}/${date.day}',
+        style: TextStyle(
+          fontSize: 11.sp,
+          color: isDark ? Colors.grey[500] : Colors.grey[600],
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+    );
+  }
+
+  List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots, bool isDark) {
+    return touchedSpots.map((barSpot) {
+      final index = barSpot.x.toInt();
+      
+      if (index >= 0 && index < widget.weightData.length) {
+        final data = widget.weightData[index];
+        final isAverage = barSpot.barIndex == 1;
+        
+        return LineTooltipItem(
+          isAverage ? '平均' : '${data.date.month}月${data.date.day}日',
+          TextStyle(
+            color: isDark ? Colors.grey[400] : Colors.grey[600],
+            fontSize: 11.sp,
+            fontWeight: FontWeight.w400,
+          ),
+          children: [
+            TextSpan(
+              text: '\n${barSpot.y.toStringAsFixed(1)} kg',
+              style: TextStyle(
+                color: isDark ? Colors.white : Colors.grey[900],
+                fontSize: 13.sp,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        );
+      }
+      
+      return LineTooltipItem('', const TextStyle());
+    }).toList();
+  }
+
+  Widget _buildProgressIndicators(ColorScheme colorScheme, bool isDark) {
+    if (widget.weightData.length < 2) return const SizedBox.shrink();
+    
+    final latestWeight = widget.weightData.last.weight;
+    final targetWeight = 65.0; // 目標体重（仮）
+    final progress = ((latestWeight - targetWeight).abs() / 10 * 100).clamp(0.0, 100.0);
+    
+    return Column(
+      children: [
+        _buildMetricRow(isDark),
+        SizedBox(height: 20.h),
+        _buildProgressBar(progress, targetWeight, latestWeight, isDark),
+      ],
+    );
+  }
+
+  Widget _buildMetricRow(bool isDark) {
+    final avgWeight = _cachedWeightSpots.map((s) => s.y).reduce((a, b) => a + b) / _cachedWeightSpots.length;
+    final minWeight = _cachedWeightSpots.map((s) => s.y).reduce(math.min);
+    final maxWeight = _cachedWeightSpots.map((s) => s.y).reduce(math.max);
+    
+    return Row(
+      children: [
+        Expanded(
+          child: _buildMetricCard(
+            '平均',
+            avgWeight.toStringAsFixed(1),
+            'kg',
+            const Color(0xFF6366F1),
+            isDark,
+          ),
+        ),
+        SizedBox(width: 12.w),
+        Expanded(
+          child: _buildMetricCard(
+            '最低',
+            minWeight.toStringAsFixed(1),
+            'kg',
+            const Color(0xFF4ECDC4),
+            isDark,
+          ),
+        ),
+        SizedBox(width: 12.w),
+        Expanded(
+          child: _buildMetricCard(
+            '最高',
+            maxWeight.toStringAsFixed(1),
+            'kg',
+            const Color(0xFFF472B6),
+            isDark,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMetricCard(String label, String value, String unit, Color color, bool isDark) {
+    return Container(
+      padding: EdgeInsets.all(16.w),
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey[850] : Colors.grey[50],
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(
+          color: isDark ? Colors.grey[800]! : Colors.grey[200]!,
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 8.w,
+                height: 8.w,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              SizedBox(width: 8.w),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 12.sp,
+                  color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8.h),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                value,
+                style: TextStyle(
+                  fontSize: 20.sp,
+                  fontWeight: FontWeight.w700,
+                  color: isDark ? Colors.white : Colors.grey[900],
+                ),
+              ),
+              SizedBox(width: 4.w),
+              Text(
+                unit,
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  color: isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProgressBar(double progress, double target, double current, bool isDark) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '目標達成まで',
+              style: TextStyle(
+                fontSize: 13.sp,
+                fontWeight: FontWeight.w500,
+                color: isDark ? Colors.grey[400] : Colors.grey[700],
+              ),
+            ),
+            Text(
+              '${(current - target).abs().toStringAsFixed(1)}kg',
+              style: TextStyle(
+                fontSize: 13.sp,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF6366F1),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: 8.h),
+        Container(
+          height: 8.h,
+          decoration: BoxDecoration(
+            color: isDark ? Colors.grey[800] : Colors.grey[200],
+            borderRadius: BorderRadius.circular(4.r),
+          ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Stack(
+                children: [
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 800),
+                    curve: Curves.easeOutCubic,
+                    width: constraints.maxWidth * (progress / 100),
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF6366F1), Color(0xFF8B5CF6)],
+                      ),
+                      borderRadius: BorderRadius.circular(4.r),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLoadingState(bool isDark) {
+    return Center(
+      child: CircularProgressIndicator(
+        color: const Color(0xFF6366F1),
+        strokeWidth: 2.w,
+      ),
+    );
+  }
+
+  Widget _buildErrorState(String error, bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 48.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データの読み込みに失敗しました',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(bool isDark) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.show_chart,
+            size: 48.w,
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'データがありません',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showDateRangePicker(BuildContext context) {
+    // 日付範囲選択の実装
+    HapticFeedback.selectionClick();
+  }
+
+  void _exportData() {
+    // データエクスポートの実装
+    HapticFeedback.mediumImpact();
+  }
+}

--- a/lib/presentation/widgets/weight_chart_widget_modern.dart
+++ b/lib/presentation/widgets/weight_chart_widget_modern.dart
@@ -138,11 +138,9 @@ class _WeightChartWidgetModernState extends State<WeightChartWidgetModern>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _buildModernHeader(context, colorScheme, isDark),
-                  SizedBox(height: 32.h),
                   _buildChart(context, colorScheme, isDark),
                   if (widget.weightData.isNotEmpty) ...[
-                    SizedBox(height: 24.h),
+                    SizedBox(height: 16.h),
                     _buildProgressIndicators(colorScheme, isDark),
                   ],
                 ],


### PR DESCRIPTION
## Summary
- ホーム画面と身体・活動画面に1週間移動平均の体重グラフを実装
- 過去3ヶ月分のHealthKitデータを表示する体重推移グラフ
- レスポンシブデザインとアニメーション効果を含むモダンなUI

## 主な変更内容
- 体重履歴取得機能の実装（HealthService）
- 7日間移動平均計算ユーティリティの追加（ChartUtils）  
- ホーム画面用シンプルグラフウィジェット（WeightChartWidgetHome）
- 身体・活動画面用詳細グラフウィジェット（WeightChartWidgetHealth）
- fl_chart v0.68.0を使用したインタラクティブな折れ線グラフ
- Material Design 3準拠のUI/UX

## UI改善
- グラスモーフィズム効果とグラデーション
- タッチインタラクション時のハプティックフィードバック
- スムーズなアニメーション効果
- レスポンシブなパディング調整

## Test plan
- [x] HealthKitデータがある場合の正常表示
- [x] HealthKitデータがない場合の空状態表示
- [x] グラフのタッチインタラクション
- [x] 画面回転時のレスポンシブ対応
- [x] シミュレータでの動作確認