### PR TITLE
feat: レシピ栄養分析機能と材料管理UI改善

### DIFF
--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner_Release.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner_Release.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/lib/core/services/food_composition_data_service.dart
+++ b/lib/core/services/food_composition_data_service.dart
@@ -1,0 +1,270 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:drift/drift.dart';
+import '../../data/models/japanese_food_composition_table.dart';
+import '../../data/datasources/app_database.dart';
+
+/// 日本食品標準成分表データ取得・管理サービス
+class FoodCompositionDataService {
+  static const String _dataUrl = 
+      'https://raw.githubusercontent.com/katoharu432/standards-tables-of-food-composition-in-japan/master/data.json';
+  
+  final AppDatabase _database;
+
+  FoodCompositionDataService(this._database);
+
+  /// GitHubからJSONデータを取得してデータベースに投入
+  Future<void> loadFoodCompositionData() async {
+    try {
+      print('食品成分データの取得を開始...');
+      
+      // GitHubからJSONデータを取得
+      final response = await http.get(
+        Uri.parse(_dataUrl),
+        headers: {
+          'User-Agent': 'HealthMeal-App/1.0',
+          'Accept': 'application/json',
+        },
+      ).timeout(const Duration(seconds: 30));
+
+      if (response.statusCode != 200) {
+        throw Exception('データの取得に失敗しました: ${response.statusCode}');
+      }
+
+      print('JSONデータの解析開始...');
+      
+      // JSONデータを解析
+      final List<dynamic> jsonData = json.decode(response.body);
+      
+      print('解析完了: ${jsonData.length}件のデータを発見');
+      
+      // データベースへの一括投入
+      await _insertFoodCompositionData(jsonData);
+      
+      print('食品成分データの投入完了');
+
+    } catch (e) {
+      print('食品成分データの取得エラー: $e');
+      throw Exception('食品成分データの取得に失敗しました: $e');
+    }
+  }
+
+  /// データベースへの一括投入
+  Future<void> _insertFoodCompositionData(List<dynamic> jsonData) async {
+    await _database.transaction(() async {
+      // 既存データをクリア（初期化の場合）
+      // await _database.delete(_database.japaneseFoodCompositionTable).go();
+      
+      int insertedCount = 0;
+      int errorCount = 0;
+      
+      for (final item in jsonData) {
+        try {
+          final foodData = JapaneseFoodCompositionTableData.fromJson(
+            item as Map<String, dynamic>
+          );
+          
+          // データベースに挿入
+          await _database.into(_database.japaneseFoodCompositionTable).insert(
+            JapaneseFoodCompositionTableCompanion.insert(
+              groupId: foodData.groupId,
+              foodId: foodData.foodId,
+              indexId: foodData.indexId,
+              foodName: foodData.foodName,
+              refuse: Value(foodData.refuse),
+              enerc: foodData.enerc != null ? Value(foodData.enerc!) : const Value.absent(),
+              enercKcal: foodData.enercKcal != null ? Value(foodData.enercKcal!) : const Value.absent(),
+              water: foodData.water != null ? Value(foodData.water!) : const Value.absent(),
+              protcaa: foodData.protcaa != null ? Value(foodData.protcaa!) : const Value.absent(),
+              prot: foodData.prot != null ? Value(foodData.prot!) : const Value.absent(),
+              fatnlea: foodData.fatnlea != null ? Value(foodData.fatnlea!) : const Value.absent(),
+              chole: foodData.chole != null ? Value(foodData.chole!) : const Value.absent(),
+              fat: foodData.fat != null ? Value(foodData.fat!) : const Value.absent(),
+              choavlm: foodData.choavlm != null ? Value(foodData.choavlm!) : const Value.absent(),
+              choavl: foodData.choavl != null ? Value(foodData.choavl!) : const Value.absent(),
+              choavldf: foodData.choavldf != null ? Value(foodData.choavldf!) : const Value.absent(),
+              fib: foodData.fib != null ? Value(foodData.fib!) : const Value.absent(),
+              polyl: foodData.polyl != null ? Value(foodData.polyl!) : const Value.absent(),
+              chocdf: foodData.chocdf != null ? Value(foodData.chocdf!) : const Value.absent(),
+              oa: foodData.oa != null ? Value(foodData.oa!) : const Value.absent(),
+              ash: foodData.ash != null ? Value(foodData.ash!) : const Value.absent(),
+              na: foodData.na != null ? Value(foodData.na!) : const Value.absent(),
+              k: foodData.k != null ? Value(foodData.k!) : const Value.absent(),
+              ca: foodData.ca != null ? Value(foodData.ca!) : const Value.absent(),
+              mg: foodData.mg != null ? Value(foodData.mg!) : const Value.absent(),
+              p: foodData.p != null ? Value(foodData.p!) : const Value.absent(),
+              fe: foodData.fe != null ? Value(foodData.fe!) : const Value.absent(),
+              zn: foodData.zn != null ? Value(foodData.zn!) : const Value.absent(),
+              cu: foodData.cu != null ? Value(foodData.cu!) : const Value.absent(),
+              mn: foodData.mn != null ? Value(foodData.mn!) : const Value.absent(),
+              iodine: foodData.iodine != null ? Value(foodData.iodine!) : const Value.absent(),
+              se: foodData.se != null ? Value(foodData.se!) : const Value.absent(),
+              cr: foodData.cr != null ? Value(foodData.cr!) : const Value.absent(),
+              mo: foodData.mo != null ? Value(foodData.mo!) : const Value.absent(),
+              retol: foodData.retol != null ? Value(foodData.retol!) : const Value.absent(),
+              carta: foodData.carta != null ? Value(foodData.carta!) : const Value.absent(),
+              cartb: foodData.cartb != null ? Value(foodData.cartb!) : const Value.absent(),
+              crypxb: foodData.crypxb != null ? Value(foodData.crypxb!) : const Value.absent(),
+              cartbeq: foodData.cartbeq != null ? Value(foodData.cartbeq!) : const Value.absent(),
+              vitaRae: foodData.vitaRae != null ? Value(foodData.vitaRae!) : const Value.absent(),
+              vitD: foodData.vitD != null ? Value(foodData.vitD!) : const Value.absent(),
+              tocphA: foodData.tocphA != null ? Value(foodData.tocphA!) : const Value.absent(),
+              tocphB: foodData.tocphB != null ? Value(foodData.tocphB!) : const Value.absent(),
+              tocphG: foodData.tocphG != null ? Value(foodData.tocphG!) : const Value.absent(),
+              tocphD: foodData.tocphD != null ? Value(foodData.tocphD!) : const Value.absent(),
+              vitK: foodData.vitK != null ? Value(foodData.vitK!) : const Value.absent(),
+              thia: foodData.thia != null ? Value(foodData.thia!) : const Value.absent(),
+              ribf: foodData.ribf != null ? Value(foodData.ribf!) : const Value.absent(),
+              nia: foodData.nia != null ? Value(foodData.nia!) : const Value.absent(),
+              ne: foodData.ne != null ? Value(foodData.ne!) : const Value.absent(),
+              vitB6A: foodData.vitB6A != null ? Value(foodData.vitB6A!) : const Value.absent(),
+              vitB12: foodData.vitB12 != null ? Value(foodData.vitB12!) : const Value.absent(),
+              fol: foodData.fol != null ? Value(foodData.fol!) : const Value.absent(),
+              pantac: foodData.pantac != null ? Value(foodData.pantac!) : const Value.absent(),
+              biot: foodData.biot != null ? Value(foodData.biot!) : const Value.absent(),
+              vitC: foodData.vitC != null ? Value(foodData.vitC!) : const Value.absent(),
+              alc: foodData.alc != null ? Value(foodData.alc!) : const Value.absent(),
+              naclEq: foodData.naclEq != null ? Value(foodData.naclEq!) : const Value.absent(),
+            ),
+          );
+          
+          insertedCount++;
+          
+          // 進捗表示（100件ごと）
+          if (insertedCount % 100 == 0) {
+            print('投入済み: $insertedCount件');
+          }
+          
+        } catch (e) {
+          errorCount++;
+          print('データ投入エラー (食品ID: ${item['foodId']}): $e');
+        }
+      }
+      
+      print('投入完了: 成功 $insertedCount件, エラー $errorCount件');
+    });
+  }
+
+  /// 食品名で検索
+  Future<List<JapaneseFoodCompositionTableData>> searchFoodsByName(String name) async {
+    final query = _database.select(_database.japaneseFoodCompositionTable)
+      ..where((tbl) => tbl.foodName.like('%$name%'))
+      ..limit(20);
+    
+    return await query.get();
+  }
+
+  /// 食品IDで取得
+  Future<JapaneseFoodCompositionTableData?> getFoodById(int foodId) async {
+    final query = _database.select(_database.japaneseFoodCompositionTable)
+      ..where((tbl) => tbl.foodId.equals(foodId));
+    
+    return await query.getSingleOrNull();
+  }
+
+  /// 食品群別に取得
+  Future<List<JapaneseFoodCompositionTableData>> getFoodsByGroup(int groupId) async {
+    final query = _database.select(_database.japaneseFoodCompositionTable)
+      ..where((tbl) => tbl.groupId.equals(groupId))
+      ..orderBy([(tbl) => OrderingTerm.asc(tbl.indexId)]);
+    
+    return await query.get();
+  }
+
+  /// データベースの食品件数を取得
+  Future<int> getFoodCount() async {
+    final countQuery = _database.selectOnly(_database.japaneseFoodCompositionTable)
+      ..addColumns([_database.japaneseFoodCompositionTable.id.count()]);
+    
+    final result = await countQuery.getSingle();
+    return result.read(_database.japaneseFoodCompositionTable.id.count()) ?? 0;
+  }
+
+  /// データベースが初期化済みかチェック
+  Future<bool> isDatabaseInitialized() async {
+    final count = await getFoodCount();
+    return count > 0;
+  }
+
+  /// 食品群一覧を取得
+  Future<Map<int, String>> getFoodGroups() async {
+    // 食品群の日本語名マッピング（簡略版）
+    return {
+      1: '穀類',
+      2: 'いも及びでん粉類',
+      3: '砂糖及び甘味類',
+      4: '豆類',
+      5: '種実類',
+      6: '野菜類',
+      7: '果実類',
+      8: 'きのこ類',
+      9: '藻類',
+      10: '魚介類',
+      11: '肉類',
+      12: '卵類',
+      13: '乳類',
+      14: '油脂類',
+      15: '菓子類',
+      16: 'し好飲料類',
+      17: '調味料及び香辛料類',
+      18: '調理加工食品類',
+    };
+  }
+
+  /// 類似食品を検索（材料名マッチング用）
+  Future<List<JapaneseFoodCompositionTableData>> findSimilarFoods(String ingredientName) async {
+    // キーワード抽出
+    final cleanedName = _cleanIngredientName(ingredientName);
+    final keywords = _extractKeywords(cleanedName);
+    
+    final results = <JapaneseFoodCompositionTableData>[];
+    
+    // 複数のキーワードで検索
+    for (final keyword in keywords) {
+      if (keyword.length >= 2) { // 2文字以上のキーワードのみ
+        final query = _database.select(_database.japaneseFoodCompositionTable)
+          ..where((tbl) => tbl.foodName.like('%$keyword%'))
+          ..limit(5);
+        
+        final matches = await query.get();
+        results.addAll(matches);
+        
+        if (results.isNotEmpty) break; // 最初にマッチしたキーワードで終了
+      }
+    }
+    
+    return results.take(10).toList(); // 重複除去して最大10件
+  }
+
+  /// 材料名をクリーニング
+  String _cleanIngredientName(String name) {
+    return name
+        .replaceAll(RegExp(r'\([^)]*\)'), '') // 括弧内削除
+        .replaceAll(RegExp(r'（[^）]*）'), '') // 全角括弧内削除
+        .replaceAll(RegExp(r'[0-9]+[.0-9]*[a-zA-Z]*'), '') // 数量削除
+        .replaceAll(RegExp(r'(大さじ|小さじ|カップ|個|本|枚|束|片|玉|切り|薄切り|みじん切り)'), '')
+        .trim();
+  }
+
+  /// キーワード抽出
+  List<String> _extractKeywords(String text) {
+    final keywords = <String>[];
+    
+    // 全体をキーワードとして追加
+    if (text.isNotEmpty) {
+      keywords.add(text);
+    }
+    
+    // 2-3文字の部分文字列も追加
+    for (int i = 0; i < text.length - 1; i++) {
+      if (i + 2 <= text.length) {
+        keywords.add(text.substring(i, i + 2));
+      }
+      if (i + 3 <= text.length) {
+        keywords.add(text.substring(i, i + 3));
+      }
+    }
+    
+    return keywords.toSet().toList(); // 重複削除
+  }
+}

--- a/lib/core/services/ingredient_extraction_service.dart
+++ b/lib/core/services/ingredient_extraction_service.dart
@@ -1,0 +1,419 @@
+import 'dart:convert';
+
+/// 材料情報
+class Ingredient {
+  final String name;
+  final double? amount;
+  final String? unit;
+  final String originalText;
+  final double confidence; // 抽出信頼度 0.0-1.0
+
+  const Ingredient({
+    required this.name,
+    this.amount,
+    this.unit,
+    required this.originalText,
+    this.confidence = 0.0,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'amount': amount,
+    'unit': unit,
+    'originalText': originalText,
+    'confidence': confidence,
+  };
+
+  @override
+  String toString() => '$name: ${amount ?? ''}${unit ?? ''} (${originalText})';
+}
+
+/// 規則ベース材料抽出サービス
+class IngredientExtractionService {
+  
+  /// メイン抽出メソッド
+  List<Ingredient> extractIngredients(String text) {
+    final ingredients = <Ingredient>[];
+    
+    // テキストの前処理
+    final normalizedText = _normalizeText(text);
+    
+    // 複数パターンで抽出
+    ingredients.addAll(_extractWithPattern1(normalizedText));
+    ingredients.addAll(_extractWithPattern2(normalizedText));
+    ingredients.addAll(_extractWithPattern3(normalizedText));
+    ingredients.addAll(_extractWithPattern4(normalizedText));
+    ingredients.addAll(_extractWithPattern5(normalizedText)); // 連続形式用パターン追加
+    ingredients.addAll(_extractWithPattern6(normalizedText)); // 日本語レシピ形式
+    ingredients.addAll(_extractWithPattern7(normalizedText)); // 行区切り形式
+    
+    // 重複除去と信頼度順ソート
+    return _deduplicateAndSort(ingredients);
+  }
+
+  /// テキスト正規化
+  String _normalizeText(String text) {
+    String result = text;
+    
+    // 全角数字を半角に変換
+    for (int i = 0; i <= 9; i++) {
+      final fullWidth = String.fromCharCode(0xFF10 + i);
+      final halfWidth = i.toString();
+      result = result.replaceAll(fullWidth, halfWidth);
+    }
+    
+    return result
+        // 全角記号を半角に
+        .replaceAll('：', ':')
+        .replaceAll('（', '(')
+        .replaceAll('）', ')')
+        .replaceAll('～', '~')
+        .replaceAll('〜', '~')
+        .replaceAll('ｇ', 'g')
+        .replaceAll('ｍｌ', 'ml')
+        .replaceAll('ｋｇ', 'kg')
+        .replaceAll('Ｌ', 'L')
+        // 括弧内の説明を適切に処理
+        .replaceAll(RegExp(r'（[^）]*なら[^）]*）'), '') // 「大きめなら1本でも」等の説明を削除
+        .replaceAll(RegExp(r'（[^）]*品）'), '') // 「市販品」等の説明を削除
+        // 連続する空白やタブを1つの空白に
+        .replaceAll(RegExp(r'[\s\t]+'), ' ')
+        .trim();
+  }
+
+  /// パターン1: 基本形 材料名: 数量単位
+  List<Ingredient> _extractWithPattern1(String text) {
+    final pattern = RegExp(
+      r'([^:\n]+):\s*([0-9]+(?:\.[0-9]+)?(?:~[0-9]+(?:\.[0-9]+)?)?)\s*(g|グラム|kg|キロ|ml|ミリリットル|L|リットル|個|コ|本|枚|束|片|玉|房|大さじ|小さじ|カップ)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final amountStr = match.group(2)!;
+      final unit = match.group(3)!;
+      
+      // 範囲指定の場合は中央値を取る
+      final amount = _parseAmount(amountStr);
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: amount,
+        unit: _normalizeUnit(unit),
+        originalText: match.group(0)!,
+        confidence: 0.9,
+      );
+    }).toList();
+  }
+
+  /// パターン2: 複合形 材料名: 数量×数量単位
+  List<Ingredient> _extractWithPattern2(String text) {
+    final pattern = RegExp(
+      r'([^:\n]+):\s*([0-9]+(?:\.[0-9]+)?)\s*(g|ml)×([0-9]+)\s*(束|個|本)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final baseAmount = double.tryParse(match.group(2)!) ?? 0;
+      final baseUnit = match.group(3)!;
+      final multiplier = double.tryParse(match.group(4)!) ?? 1;
+      final containerUnit = match.group(5)!;
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: baseAmount * multiplier,
+        unit: baseUnit,
+        originalText: match.group(0)!,
+        confidence: 0.8,
+      );
+    }).toList();
+  }
+
+  /// パターン3: 括弧付き 材料名(詳細): 数量単位
+  List<Ingredient> _extractWithPattern3(String text) {
+    final pattern = RegExp(
+      r'([^:\n]+(?:\([^)]+\))?[^:\n]*?):\s*([0-9]+(?:\.[0-9]+)?(?:~[0-9]+(?:\.[0-9]+)?)?)\s*(g|グラム|kg|キロ|ml|ミリリットル|L|リットル|個|コ|本|枚|束|片|玉|房|大さじ|小さじ|カップ)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final amountStr = match.group(2)!;
+      final unit = match.group(3)!;
+      
+      final amount = _parseAmount(amountStr);
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: amount,
+        unit: _normalizeUnit(unit),
+        originalText: match.group(0)!,
+        confidence: 0.85,
+      );
+    }).toList();
+  }
+
+  /// パターン4: 曖昧表記 材料名: 少々/適量/適宜
+  List<Ingredient> _extractWithPattern4(String text) {
+    final pattern = RegExp(
+      r'([^:\n]+):\s*(少々|適量|適宜)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final amountDesc = match.group(2)!;
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: null,
+        unit: amountDesc,
+        originalText: match.group(0)!,
+        confidence: 0.7,
+      );
+    }).toList();
+  }
+
+  /// パターン5: 連続形式（区切り文字なし）材料名数量単位 形式
+  List<Ingredient> _extractWithPattern5(String text) {
+    // 材料名+数量+単位の連続パターン
+    final pattern = RegExp(
+      r'([あ-んア-ン一-龯]+)([0-9]+(?:\.[0-9]+)?(?:~[0-9]+(?:\.[0-9]+)?)?)\s*(g|グラム|kg|キロ|ml|ミリリットル|L|リットル|個|コ|本|枚|束|片|玉|房|大さじ|小さじ|カップ)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final amountStr = match.group(2)!;
+      final unit = match.group(3)!;
+      
+      final amount = _parseAmount(amountStr);
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: amount,
+        unit: _normalizeUnit(unit),
+        originalText: match.group(0)!,
+        confidence: 0.75,
+      );
+    }).toList();
+  }
+
+  /// パターン6: 日本語レシピ形式 材料名　…　数量単位
+  List<Ingredient> _extractWithPattern6(String text) {
+    // 日本語レシピでよく使われる「材料名　…　数量単位」形式
+    final pattern = RegExp(
+      r'([あ-んア-ンー一-龯a-zA-Z]+(?:\([^)]*\))?[あ-んア-ンー一-龯a-zA-Z]*)\s*[…・\s]+\s*([0-9]+(?:\.[0-9]+)?(?:[〜~][0-9]+(?:\.[0-9]+)?)?)\s*(ｇ|g|グラム|ｋｇ|kg|キロ|ｍｌ|ml|ミリリットル|Ｌ|L|リットル|個|コ|本|枚|束|片|玉|房|大さじ|小さじ|カップ|人分)',
+      multiLine: true,
+    );
+    
+    return pattern.allMatches(text).map((match) {
+      final name = match.group(1)!.trim();
+      final amountStr = match.group(2)!;
+      final unit = match.group(3)!;
+      
+      final amount = _parseAmount(amountStr.replaceAll('〜', '~'));
+      
+      return Ingredient(
+        name: _cleanIngredientName(name),
+        amount: amount,
+        unit: _normalizeUnit(unit),
+        originalText: match.group(0)!,
+        confidence: 0.85,
+      );
+    }).toList();
+  }
+
+  /// パターン7: 行区切り形式 - 1行に1つの材料
+  List<Ingredient> _extractWithPattern7(String text) {
+    final ingredients = <Ingredient>[];
+    final lines = text.split('\n');
+    
+    for (final line in lines) {
+      final cleanLine = line.trim();
+      if (cleanLine.isEmpty || cleanLine.startsWith('【') || cleanLine.contains('作り方')) {
+        continue;
+      }
+      
+      // 材料っぽい行かチェック
+      if (_looksLikeIngredient(cleanLine)) {
+        // 材料名と数量を分離
+        final match = RegExp(
+          r'^([あ-んア-ンー一-龯a-zA-Z\s]+?)(?:\s*[…・]\s*)?([0-9]+(?:\.[0-9]+)?(?:[〜~][0-9]+(?:\.[0-9]+)?)?)\s*(ｇ|g|グラム|ｋｇ|kg|キロ|ｍｌ|ml|ミリリットル|Ｌ|L|リットル|個|コ|本|枚|束|片|玉|房|大さじ|小さじ|カップ|人分)',
+        ).firstMatch(cleanLine);
+        
+        if (match != null) {
+          final name = match.group(1)!.trim();
+          final amountStr = match.group(2)!;
+          final unit = match.group(3)!;
+          
+          final amount = _parseAmount(amountStr.replaceAll('〜', '~'));
+          
+          ingredients.add(Ingredient(
+            name: _cleanIngredientName(name),
+            amount: amount,
+            unit: _normalizeUnit(unit),
+            originalText: cleanLine,
+            confidence: 0.8,
+          ));
+        } else {
+          // 数量が明記されていない材料
+          final simpleMatch = RegExp(r'^([あ-んア-ンー一-龯a-zA-Z\s]+?)(?:\s*[…・]\s*)?(少々|適量|適宜|お好みで)').firstMatch(cleanLine);
+          if (simpleMatch != null) {
+            final name = simpleMatch.group(1)!.trim();
+            final amountDesc = simpleMatch.group(2)!;
+            
+            ingredients.add(Ingredient(
+              name: _cleanIngredientName(name),
+              amount: null,
+              unit: amountDesc,
+              originalText: cleanLine,
+              confidence: 0.7,
+            ));
+          } else {
+            // 「…」区切りだが単位がない材料（例：「オリーブオイル … 適量」）
+            final fallbackMatch = RegExp(r'^([あ-んア-ンー一-龯a-zA-Z\s]+)\s*[…・]\s*(.*)').firstMatch(cleanLine);
+            if (fallbackMatch != null) {
+              final name = fallbackMatch.group(1)!.trim();
+              final rest = fallbackMatch.group(2)!.trim();
+              
+              // 残りの部分が材料名の続きかどうか判定
+              if (rest.isNotEmpty && rest.length < 20) {
+                ingredients.add(Ingredient(
+                  name: _cleanIngredientName(name),
+                  amount: null,
+                  unit: rest.isNotEmpty ? rest : null,
+                  originalText: cleanLine,
+                  confidence: 0.6,
+                ));
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    return ingredients;
+  }
+
+  /// 材料っぽい行かどうかを判定
+  bool _looksLikeIngredient(String line) {
+    // 説明文や指示文を除外
+    if (RegExp(r'(大きめなら|小さめなら|お好みで|場合は|時は|なら|ば|とき)').hasMatch(line)) {
+      return false;
+    }
+    
+    // 数字が含まれているか、材料らしいキーワードが含まれている
+    if (RegExp(r'[0-9]').hasMatch(line)) return true;
+    if (RegExp(r'(少々|適量|適宜|お好みで)').hasMatch(line)) return true;
+    
+    // 一般的な材料名のパターン
+    final commonIngredients = [
+      'トマト', 'なす', 'そうめん', '大葉', 'ごま', 'ポン酢', 'オリーブ', '玉ねぎ',
+      '人参', 'にんじん', 'じゃがいも', 'キャベツ', 'レタス', 'きゅうり', 'ピーマン',
+      '鶏肉', '豚肉', '牛肉', '魚', 'エビ', 'イカ', '卵', '牛乳', '豆腐', '米', 'パン',
+      '醤油', '味噌', '塩', '砂糖', '酢', '油', 'バター', 'マヨネーズ'
+    ];
+    
+    for (final ingredient in commonIngredients) {
+      if (line.contains(ingredient)) return true;
+    }
+    
+    return false;
+  }
+
+  /// 数量解析（範囲指定対応）
+  double? _parseAmount(String amountStr) {
+    // 日本語数字を半角数字に変換
+    String normalizedAmount = _convertJapaneseNumbers(amountStr);
+    
+    if (normalizedAmount.contains('~')) {
+      final parts = normalizedAmount.split('~');
+      if (parts.length == 2) {
+        final min = double.tryParse(parts[0]) ?? 0;
+        final max = double.tryParse(parts[1]) ?? 0;
+        return (min + max) / 2; // 中央値
+      }
+    }
+    return double.tryParse(normalizedAmount);
+  }
+
+  /// 日本語数字を半角数字に変換
+  String _convertJapaneseNumbers(String text) {
+    const japaneseNumbers = {
+      '一': '1', '二': '2', '三': '3', '四': '4', '五': '5',
+      '六': '6', '七': '7', '八': '8', '九': '9', '十': '10',
+      '１': '1', '２': '2', '３': '3', '４': '4', '５': '5',
+      '６': '6', '７': '7', '８': '8', '９': '9', '０': '0',
+    };
+    
+    String result = text;
+    japaneseNumbers.forEach((japanese, arabic) {
+      result = result.replaceAll(japanese, arabic);
+    });
+    
+    return result;
+  }
+
+  /// 材料名クリーニング
+  String _cleanIngredientName(String name) {
+    return name
+        // 不要な記号を削除
+        .replaceAll(RegExp(r'[・･]'), '')
+        // 余分な空白を削除
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+
+  /// 単位正規化
+  String _normalizeUnit(String unit) {
+    const unitMap = {
+      'グラム': 'g',
+      'ｇ': 'g',
+      'キロ': 'kg',
+      'ｋｇ': 'kg', 
+      'ミリリットル': 'ml',
+      'ｍｌ': 'ml',
+      'リットル': 'L',
+      'Ｌ': 'L',
+      'コ': '個',
+      '人分': '人前',
+    };
+    return unitMap[unit] ?? unit;
+  }
+
+  /// 重複除去と信頼度順ソート
+  List<Ingredient> _deduplicateAndSort(List<Ingredient> ingredients) {
+    final uniqueIngredients = <String, Ingredient>{};
+    
+    for (final ingredient in ingredients) {
+      final key = ingredient.name.toLowerCase();
+      if (!uniqueIngredients.containsKey(key) || 
+          uniqueIngredients[key]!.confidence < ingredient.confidence) {
+        uniqueIngredients[key] = ingredient;
+      }
+    }
+    
+    final result = uniqueIngredients.values.toList();
+    result.sort((a, b) => b.confidence.compareTo(a.confidence));
+    return result;
+  }
+
+  /// 抽出結果の統計情報
+  Map<String, dynamic> getExtractionStats(List<Ingredient> ingredients) {
+    final totalCount = ingredients.length;
+    final withAmount = ingredients.where((i) => i.amount != null).length;
+    final avgConfidence = ingredients.isEmpty 
+        ? 0.0 
+        : ingredients.map((i) => i.confidence).reduce((a, b) => a + b) / totalCount;
+    
+    return {
+      'totalCount': totalCount,
+      'withAmount': withAmount,
+      'withoutAmount': totalCount - withAmount,
+      'averageConfidence': avgConfidence,
+      'highConfidenceCount': ingredients.where((i) => i.confidence >= 0.8).length,
+    };
+  }
+}

--- a/lib/core/services/nutrition_calculation_service.dart
+++ b/lib/core/services/nutrition_calculation_service.dart
@@ -1,0 +1,312 @@
+import '../../data/datasources/app_database.dart';
+import '../../data/models/nutrition_table.dart';
+import '../../data/models/food_mapping_table.dart';
+import '../services/ingredient_extraction_service.dart';
+
+/// 栄養計算結果
+class NutritionCalculationResult {
+  final double totalEnergy;
+  final double totalProtein;
+  final double totalFat;
+  final double totalCarbohydrate;
+  final double totalSodium;
+  final double totalFiber;
+  final List<IngredientNutrition> ingredientDetails;
+  final double confidence; // 計算全体の信頼度
+  final List<String> unmatchedIngredients; // マッチしなかった材料
+  final Map<String, double> vitamins;
+  final Map<String, double> minerals;
+
+  const NutritionCalculationResult({
+    required this.totalEnergy,
+    required this.totalProtein,
+    required this.totalFat,
+    required this.totalCarbohydrate,
+    required this.totalSodium,
+    required this.totalFiber,
+    required this.ingredientDetails,
+    required this.confidence,
+    required this.unmatchedIngredients,
+    required this.vitamins,
+    required this.minerals,
+  });
+
+  /// 基本栄養素のMap取得
+  Map<String, double> getBasicNutrition() {
+    return {
+      'energy': totalEnergy,
+      'protein': totalProtein,
+      'fat': totalFat,
+      'carbohydrate': totalCarbohydrate,
+    };
+  }
+
+  /// PFCバランス計算（タンパク質:脂質:炭水化物の比率）
+  Map<String, double> getPFCBalance() {
+    final proteinCal = totalProtein * 4; // 1g = 4kcal
+    final fatCal = totalFat * 9; // 1g = 9kcal
+    final carbCal = totalCarbohydrate * 4; // 1g = 4kcal
+    final total = proteinCal + fatCal + carbCal;
+    
+    if (total == 0) {
+      return {'protein': 0, 'fat': 0, 'carbohydrate': 0};
+    }
+    
+    return {
+      'protein': (proteinCal / total) * 100,
+      'fat': (fatCal / total) * 100,
+      'carbohydrate': (carbCal / total) * 100,
+    };
+  }
+}
+
+/// 材料ごとの栄養情報
+class IngredientNutrition {
+  final String ingredientName;
+  final double amountInGrams;
+  final double energy;
+  final double protein;
+  final double fat;
+  final double carbohydrate;
+  final double confidence;
+  final String? matchedFoodName;
+
+  const IngredientNutrition({
+    required this.ingredientName,
+    required this.amountInGrams,
+    required this.energy,
+    required this.protein,
+    required this.fat,
+    required this.carbohydrate,
+    required this.confidence,
+    this.matchedFoodName,
+  });
+}
+
+/// 栄養計算サービス
+class NutritionCalculationService {
+  final AppDatabase _database;
+
+  NutritionCalculationService(this._database);
+
+  /// 材料リストから栄養情報を計算
+  Future<NutritionCalculationResult> calculateNutrition(
+    List<Ingredient> ingredients,
+  ) async {
+    final ingredientDetails = <IngredientNutrition>[];
+    final unmatchedIngredients = <String>[];
+    
+    double totalEnergy = 0;
+    double totalProtein = 0;
+    double totalFat = 0;
+    double totalCarbohydrate = 0;
+    double totalSodium = 0;
+    double totalFiber = 0;
+    
+    final vitamins = <String, double>{};
+    final minerals = <String, double>{};
+    
+    double totalConfidence = 0;
+    int matchedCount = 0;
+
+    for (final ingredient in ingredients) {
+      // 材料名から栄養データを検索
+      final nutritionResult = await _findNutritionData(ingredient);
+      
+      if (nutritionResult != null) {
+        final mapping = nutritionResult['mapping'] as FoodMappingTableData;
+        final nutrition = nutritionResult['nutrition'] as NutritionDataTableData;
+        
+        // 材料の重量をグラムに変換
+        final amountInGrams = mapping.convertToGrams(
+          ingredient.amount ?? 0, 
+          ingredient.unit,
+        ) * mapping.ediblePortion;
+
+        // 100gあたりの栄養価から実際の量を計算
+        final multiplier = amountInGrams / 100;
+        
+        final ingredientEnergy = (nutrition.energy ?? 0) * multiplier;
+        final ingredientProtein = (nutrition.protein ?? 0) * multiplier;
+        final ingredientFat = (nutrition.fat ?? 0) * multiplier;
+        final ingredientCarb = (nutrition.carbohydrate ?? 0) * multiplier;
+        
+        // 合計に追加
+        totalEnergy += ingredientEnergy;
+        totalProtein += ingredientProtein;
+        totalFat += ingredientFat;
+        totalCarbohydrate += ingredientCarb;
+        totalSodium += (nutrition.sodium ?? 0) * multiplier;
+        totalFiber += (nutrition.dietaryFiber ?? 0) * multiplier;
+        
+        // ビタミン・ミネラルの合計
+        _addVitaminsAndMinerals(nutrition, multiplier, vitamins, minerals);
+        
+        // 材料詳細を追加
+        ingredientDetails.add(IngredientNutrition(
+          ingredientName: ingredient.name,
+          amountInGrams: amountInGrams,
+          energy: ingredientEnergy,
+          protein: ingredientProtein,
+          fat: ingredientFat,
+          carbohydrate: ingredientCarb,
+          confidence: mapping.confidence * ingredient.confidence,
+          matchedFoodName: nutrition.foodName,
+        ));
+        
+        totalConfidence += mapping.confidence * ingredient.confidence;
+        matchedCount++;
+      } else {
+        unmatchedIngredients.add(ingredient.name);
+      }
+    }
+
+    final averageConfidence = matchedCount > 0 ? totalConfidence / matchedCount : 0.0;
+
+    return NutritionCalculationResult(
+      totalEnergy: totalEnergy,
+      totalProtein: totalProtein,
+      totalFat: totalFat,
+      totalCarbohydrate: totalCarbohydrate,
+      totalSodium: totalSodium,
+      totalFiber: totalFiber,
+      ingredientDetails: ingredientDetails,
+      confidence: averageConfidence,
+      unmatchedIngredients: unmatchedIngredients,
+      vitamins: vitamins,
+      minerals: minerals,
+    );
+  }
+
+  /// 材料名から栄養データを検索
+  Future<Map<String, dynamic>?> _findNutritionData(Ingredient ingredient) async {
+    // 1. 完全一致検索
+    final exactMatch = await _searchByExactMatch(ingredient.name);
+    if (exactMatch != null) return exactMatch;
+    
+    // 2. 部分一致検索
+    final partialMatch = await _searchByPartialMatch(ingredient.name);
+    if (partialMatch != null) return partialMatch;
+    
+    // 3. 類似度検索（将来的にAI補完）
+    final similarMatch = await _searchBySimilarity(ingredient.name);
+    if (similarMatch != null) return similarMatch;
+    
+    return null;
+  }
+
+  /// 完全一致検索
+  Future<Map<String, dynamic>?> _searchByExactMatch(String ingredientName) async {
+    final query = _database.select(_database.foodMappingTable).join([
+      leftOuterJoin(
+        _database.nutritionDataTable,
+        _database.nutritionDataTable.id.equalsExp(
+          _database.foodMappingTable.nutritionDataId,
+        ),
+      ),
+    ])..where(_database.foodMappingTable.ingredientName.equals(ingredientName));
+
+    final result = await query.getSingleOrNull();
+    if (result != null) {
+      return {
+        'mapping': result.readTable(_database.foodMappingTable),
+        'nutrition': result.readTable(_database.nutritionDataTable),
+      };
+    }
+    return null;
+  }
+
+  /// 部分一致検索
+  Future<Map<String, dynamic>?> _searchByPartialMatch(String ingredientName) async {
+    final query = _database.select(_database.foodMappingTable).join([
+      leftOuterJoin(
+        _database.nutritionDataTable,
+        _database.nutritionDataTable.id.equalsExp(
+          _database.foodMappingTable.nutritionDataId,
+        ),
+      ),
+    ])..where(_database.foodMappingTable.ingredientName.like('%$ingredientName%'))
+      ..orderBy([OrderingTerm.desc(_database.foodMappingTable.confidence)]);
+
+    final results = await query.get();
+    if (results.isNotEmpty) {
+      final result = results.first;
+      return {
+        'mapping': result.readTable(_database.foodMappingTable),
+        'nutrition': result.readTable(_database.nutritionDataTable),
+      };
+    }
+    return null;
+  }
+
+  /// 類似度検索（将来的に改善）
+  Future<Map<String, dynamic>?> _searchBySimilarity(String ingredientName) async {
+    // 現在は簡単なキーワードマッチング
+    final keywords = _extractKeywords(ingredientName);
+    
+    for (final keyword in keywords) {
+      final result = await _searchByPartialMatch(keyword);
+      if (result != null) return result;
+    }
+    
+    return null;
+  }
+
+  /// キーワード抽出（簡易版）
+  List<String> _extractKeywords(String text) {
+    // 括弧内削除
+    String cleaned = text.replaceAll(RegExp(r'\([^)]*\)'), '');
+    cleaned = cleaned.replaceAll(RegExp(r'（[^）]*）'), '');
+    
+    // 一般的な修飾語を削除
+    final modifiers = ['新鮮な', '国産', '冷凍', '乾燥', '粉末', '液体', 'みじん切り', 'せん切り', '角切り'];
+    for (final modifier in modifiers) {
+      cleaned = cleaned.replaceAll(modifier, '');
+    }
+    
+    return [cleaned.trim()];
+  }
+
+  /// ビタミン・ミネラルを合計に追加
+  void _addVitaminsAndMinerals(
+    NutritionDataTableData nutrition,
+    double multiplier,
+    Map<String, double> vitamins,
+    Map<String, double> minerals,
+  ) {
+    // ビタミン
+    vitamins['vitaminA'] = (vitamins['vitaminA'] ?? 0) + 
+        (nutrition.retinolActivityEquivalent ?? 0) * multiplier;
+    vitamins['vitaminD'] = (vitamins['vitaminD'] ?? 0) + 
+        (nutrition.vitaminD ?? 0) * multiplier;
+    vitamins['vitaminB1'] = (vitamins['vitaminB1'] ?? 0) + 
+        (nutrition.vitaminB1 ?? 0) * multiplier;
+    vitamins['vitaminB2'] = (vitamins['vitaminB2'] ?? 0) + 
+        (nutrition.vitaminB2 ?? 0) * multiplier;
+    vitamins['vitaminC'] = (vitamins['vitaminC'] ?? 0) + 
+        (nutrition.vitaminC ?? 0) * multiplier;
+    
+    // ミネラル
+    minerals['calcium'] = (minerals['calcium'] ?? 0) + 
+        (nutrition.calcium ?? 0) * multiplier;
+    minerals['iron'] = (minerals['iron'] ?? 0) + 
+        (nutrition.iron ?? 0) * multiplier;
+    minerals['potassium'] = (minerals['potassium'] ?? 0) + 
+        (nutrition.potassium ?? 0) * multiplier;
+    minerals['magnesium'] = (minerals['magnesium'] ?? 0) + 
+        (nutrition.magnesium ?? 0) * multiplier;
+  }
+
+  /// 栄養計算の統計情報
+  Map<String, dynamic> getCalculationStats(NutritionCalculationResult result) {
+    return {
+      'matchedIngredients': result.ingredientDetails.length,
+      'unmatchedIngredients': result.unmatchedIngredients.length,
+      'totalIngredients': result.ingredientDetails.length + result.unmatchedIngredients.length,
+      'matchRate': result.ingredientDetails.length / 
+          (result.ingredientDetails.length + result.unmatchedIngredients.length) * 100,
+      'averageConfidence': result.confidence,
+      'pfcBalance': result.getPFCBalance(),
+    };
+  }
+}

--- a/lib/core/services/recipe_nutrition_analysis_service.dart
+++ b/lib/core/services/recipe_nutrition_analysis_service.dart
@@ -1,0 +1,442 @@
+import 'dart:convert';
+import '../../data/models/japanese_food_composition_table.dart';
+import '../../data/datasources/app_database.dart';
+import 'ingredient_extraction_service.dart';
+import 'food_composition_data_service.dart';
+
+/// レシピ栄養分析サービス
+class RecipeNutritionAnalysisService {
+  final IngredientExtractionService _extractor = IngredientExtractionService();
+  final FoodCompositionDataService _foodService;
+  
+  RecipeNutritionAnalysisService(AppDatabase database) 
+      : _foodService = FoodCompositionDataService(database);
+
+  /// レシピ本文から材料・栄養を分析
+  Future<RecipeNutritionResult> analyzeRecipe(String recipeText) async {
+    print('デバッグ: RecipeNutritionAnalysisService.analyzeRecipe開始');
+    print('デバッグ: レシピ本文 = ${recipeText.substring(0, recipeText.length > 100 ? 100 : recipeText.length)}...');
+    
+    // 1. 材料抽出
+    final ingredients = _extractor.extractIngredients(recipeText);
+    final stats = _extractor.getExtractionStats(ingredients);
+    print('デバッグ: 抽出された材料数 = ${ingredients.length}');
+    
+    // 2. 食品マッチング
+    final matchResults = <IngredientMatchResult>[];
+    
+    for (final ingredient in ingredients) {
+      // 暫定的に簡単な食品マッチングを使用
+      final matchedFood = _findBasicFood(ingredient.name);
+      print('デバッグ: ${ingredient.name} → ${matchedFood?.foodName ?? "マッチなし"}');
+      
+      matchResults.add(IngredientMatchResult(
+        ingredient: ingredient,
+        matchedFood: matchedFood,
+        confidence: matchedFood != null ? 0.8 : 0.0,
+      ));
+    }
+    
+    // 3. 栄養計算
+    final nutrition = _calculateNutrition(matchResults);
+    
+    // 4. PFCバランス
+    final pfcBalance = _calculatePFCBalance(nutrition);
+    
+    return RecipeNutritionResult(
+      ingredients: ingredients,
+      matchResults: matchResults,
+      nutrition: nutrition,
+      pfcBalance: pfcBalance,
+      extractionStats: stats,
+      ingredientsJson: _ingredientsToJson(ingredients),
+      rawText: recipeText,
+    );
+  }
+
+  /// 栄養計算
+  RecipeNutrition _calculateNutrition(List<IngredientMatchResult> matchResults) {
+    double totalEnergy = 0;
+    double totalProtein = 0;
+    double totalFat = 0;
+    double totalCarbs = 0;
+    double totalSalt = 0;
+    double totalFiber = 0;
+    double totalVitaminC = 0;
+    
+    for (final result in matchResults) {
+      if (result.matchedFood != null) {
+        final ingredient = result.ingredient;
+        final food = result.matchedFood!;
+        
+        // 重量をグラムに変換（可食部重量考慮）  
+        final grossWeight = _convertToGrams(ingredient.amount ?? 0, ingredient.unit);
+        final edibleWeight = grossWeight * (1 - (food.refuse ?? 0) / 100);
+        final multiplier = edibleWeight / 100; // 100gあたりの値から実際の量を計算
+        
+        // 栄養素計算
+        totalEnergy += (food.enercKcal ?? 0) * multiplier;
+        totalProtein += (food.prot ?? 0) * multiplier;
+        totalFat += (food.fat ?? 0) * multiplier;
+        totalCarbs += (food.choavl ?? 0) * multiplier;
+        totalSalt += (food.na ?? 0) * multiplier * 2.54 / 1000; // ナトリウム→食塩相当量
+        totalFiber += (food.fib ?? 0) * multiplier;
+        totalVitaminC += (food.vitC ?? 0) * multiplier;
+      }
+    }
+    
+    return RecipeNutrition(
+      energy: totalEnergy,
+      protein: totalProtein,
+      fat: totalFat,
+      carbohydrate: totalCarbs,
+      salt: totalSalt,
+      fiber: totalFiber,
+      vitaminC: totalVitaminC,
+    );
+  }
+
+  /// PFCバランス計算
+  PFCBalance _calculatePFCBalance(RecipeNutrition nutrition) {
+    final proteinCal = nutrition.protein * 4; // 1g = 4kcal
+    final fatCal = nutrition.fat * 9; // 1g = 9kcal
+    final carbsCal = nutrition.carbohydrate * 4; // 1g = 4kcal
+    final total = proteinCal + fatCal + carbsCal;
+    
+    if (total == 0) {
+      return PFCBalance(protein: 0, fat: 0, carbohydrate: 0);
+    }
+    
+    return PFCBalance(
+      protein: (proteinCal / total) * 100,
+      fat: (fatCal / total) * 100,
+      carbohydrate: (carbsCal / total) * 100,
+    );
+  }
+
+  /// 単位変換
+  double _convertToGrams(double amount, String? unit) {
+    final normalizedUnit = (unit ?? '').toLowerCase();
+    
+    final conversionMap = {
+      'g': 1.0,
+      'kg': 1000.0,
+      'ml': 1.0, // 液体は1ml=1gと仮定
+      '個': 100.0, // 野菜1個の平均重量
+      'コ': 100.0,
+      '本': 50.0,  // 野菜1本の平均重量
+      '枚': 100.0, // 肉1枚の平均重量
+      '束': 100.0,
+      '大さじ': 15.0,
+      '小さじ': 5.0,
+    };
+    
+    return amount * (conversionMap[normalizedUnit] ?? 1.0);
+  }
+
+  /// 改善された食品マッチング
+  JapaneseFoodCompositionTableData? _findBasicFood(String ingredientName) {
+    final cleanedName = ingredientName.toLowerCase().trim();
+    
+    // 1. 完全一致の確認
+    final exactMatch = _findExactMatch(cleanedName);
+    if (exactMatch != null) return exactMatch;
+    
+    // 2. 部分一致の確認
+    final partialMatch = _findPartialMatch(cleanedName);
+    if (partialMatch != null) return partialMatch;
+    
+    // 3. シノニム（同義語）マッチング
+    final synonymMatch = _findSynonymMatch(cleanedName);
+    if (synonymMatch != null) return synonymMatch;
+    
+    // 4. ファジーマッチング（編集距離ベース）
+    final fuzzyMatch = _findFuzzyMatch(cleanedName);
+    if (fuzzyMatch != null) return fuzzyMatch;
+    
+    return null;
+  }
+
+  /// 完全一致検索
+  JapaneseFoodCompositionTableData? _findExactMatch(String name) {
+    // 基本的な食品マッピング（テスト用）
+    final basicFoods = {
+      '豚': JapaneseFoodCompositionTableData(
+        id: 1, groupId: 11, foodId: 11005, indexId: 1,
+        foodName: 'ぶた 肩ロース 脂身つき 生',
+        refuse: 0.0, enercKcal: 253.0, prot: 17.1, fat: 19.2, choavl: 0.2,
+        na: 54.0, k: 300.0, ca: 5.0, fe: 0.6, fib: 0.0, vitC: 1.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'なす': JapaneseFoodCompositionTableData(
+        id: 2, groupId: 6, foodId: 6014, indexId: 1,
+        foodName: 'なす 果実 生',
+        refuse: 0.0, enercKcal: 22.0, prot: 1.1, fat: 0.1, choavl: 5.1,
+        na: 1.0, k: 220.0, ca: 18.0, fe: 0.3, fib: 2.2, vitC: 5.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'そうめん': JapaneseFoodCompositionTableData(
+        id: 3, groupId: 1, foodId: 1020, indexId: 1,
+        foodName: 'そうめん・ひやむぎ 乾',
+        refuse: 0.0, enercKcal: 356.0, prot: 9.5, fat: 1.1, choavl: 72.7,
+        na: 1800.0, k: 120.0, ca: 9.0, fe: 0.6, fib: 2.5, vitC: 0.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'だし': JapaneseFoodCompositionTableData(
+        id: 4, groupId: 19, foodId: 19001, indexId: 1,
+        foodName: 'かつおだし',
+        refuse: 0.0, enercKcal: 3.0, prot: 0.8, fat: 0.0, choavl: 0.1,
+        na: 270.0, k: 88.0, ca: 2.0, fe: 0.0, fib: 0.0, vitC: 0.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'ピーマン': JapaneseFoodCompositionTableData(
+        id: 5, groupId: 6, foodId: 6024, indexId: 1,
+        foodName: 'ピーマン 果実 生',
+        refuse: 0.0, enercKcal: 22.0, prot: 0.9, fat: 0.2, choavl: 5.1,
+        na: 1.0, k: 190.0, ca: 11.0, fe: 0.4, fib: 2.3, vitC: 76.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      '鶏': JapaneseFoodCompositionTableData(
+        id: 6, groupId: 11, foodId: 11015, indexId: 1,
+        foodName: 'にわとり もも 皮つき 生',
+        refuse: 0.0, enercKcal: 200.0, prot: 16.2, fat: 14.0, choavl: 0.0,
+        na: 98.0, k: 270.0, ca: 6.0, fe: 0.6, fib: 0.0, vitC: 3.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'いんげん': JapaneseFoodCompositionTableData(
+        id: 7, groupId: 6, foodId: 6015, indexId: 1,
+        foodName: 'いんげんまめ さやいんげん 若ざや 生',
+        refuse: 0.0, enercKcal: 23.0, prot: 1.8, fat: 0.1, choavl: 4.6,
+        na: 1.0, k: 260.0, ca: 40.0, fe: 0.7, fib: 2.4, vitC: 8.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'トマト': JapaneseFoodCompositionTableData(
+        id: 8, groupId: 6, foodId: 6031, indexId: 1,
+        foodName: 'トマト 果実 生',
+        refuse: 0.0, enercKcal: 20.0, prot: 0.7, fat: 0.1, choavl: 4.7,
+        na: 3.0, k: 210.0, ca: 7.0, fe: 0.2, fib: 1.0, vitC: 15.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      '大葉': JapaneseFoodCompositionTableData(
+        id: 9, groupId: 6, foodId: 6041, indexId: 1,
+        foodName: 'しそ 葉 生',
+        refuse: 0.0, enercKcal: 37.0, prot: 3.9, fat: 0.1, choavl: 7.5,
+        na: 1.0, k: 500.0, ca: 230.0, fe: 1.7, fib: 7.3, vitC: 26.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'ポン酢': JapaneseFoodCompositionTableData(
+        id: 10, groupId: 18, foodId: 18001, indexId: 1,
+        foodName: 'ぽん酢',
+        refuse: 0.0, enercKcal: 56.0, prot: 2.1, fat: 0.0, choavl: 12.2,  
+        na: 3200.0, k: 130.0, ca: 8.0, fe: 0.4, fib: 0.0, vitC: 12.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'オリーブオイル': JapaneseFoodCompositionTableData(
+        id: 11, groupId: 14, foodId: 14003, indexId: 1,
+        foodName: 'オリーブ油',
+        refuse: 0.0, enercKcal: 921.0, prot: 0.0, fat: 100.0, choavl: 0.0,
+        na: 0.0, k: 0.0, ca: 0.0, fe: 0.0, fib: 0.0, vitC: 0.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      'ごま': JapaneseFoodCompositionTableData(
+        id: 12, groupId: 3, foodId: 3020, indexId: 1,
+        foodName: 'ごま いり',
+        refuse: 0.0, enercKcal: 599.0, prot: 19.8, fat: 54.2, choavl: 18.5,
+        na: 2.0, k: 400.0, ca: 1200.0, fe: 9.9, fib: 10.8, vitC: 0.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+    };
+    
+    // 完全一致検索
+    return basicFoods[name];
+  }
+
+  /// 部分一致検索
+  JapaneseFoodCompositionTableData? _findPartialMatch(String name) {
+    final basicFoods = _getBasicFoods();
+    
+    for (final entry in basicFoods.entries) {
+      if (name.contains(entry.key) || entry.key.contains(name)) {
+        return entry.value;
+      }
+    }
+    return null;
+  }
+
+  /// シノニム（同義語）マッチング
+  JapaneseFoodCompositionTableData? _findSynonymMatch(String name) {
+    final basicFoods = _getBasicFoods();
+    final synonyms = {
+      'しそ': '大葉',
+      'オリーブ': 'オリーブオイル',
+      'いりごま': 'ごま',
+      '白ごま': 'ごま',
+      'しろごま': 'ごま',
+      'いり': 'ごま',
+      'ぽん酢': 'ポン酢',
+      'ポンズ': 'ポン酢',
+      'しょうゆ': 'ポン酢',
+      '醤油': 'ポン酢',
+      // 追加のシノニム
+      'にんじん': '人参',
+      'たまねぎ': '玉ねぎ',
+      'きゅうり': '胡瓜',
+      'じゃがいも': 'じゃが芋',
+      'さつまいも': 'さつま芋',
+      'だいこん': '大根',
+      'はくさい': '白菜',
+      '鳥肉': '鶏肉',
+      'とり肉': '鶏肉',
+      'ぶた肉': '豚肉',
+      '牛肉': '牛',
+      'びーふ': '牛肉',
+      'ポーク': '豚肉',
+      'チキン': '鶏肉',
+    };
+    
+    for (final entry in synonyms.entries) {
+      if (name.contains(entry.key)) {
+        return basicFoods[entry.value];
+      }
+    }
+    return null;
+  }
+
+  /// ファジーマッチング（編集距離ベース）
+  JapaneseFoodCompositionTableData? _findFuzzyMatch(String name) {
+    final basicFoods = _getBasicFoods();
+    
+    // 編集距離が2以下で最も近い食品を探す
+    String? bestMatch;
+    int minDistance = 3; // 閾値
+    
+    for (final foodName in basicFoods.keys) {
+      final distance = _calculateEditDistance(name, foodName);
+      if (distance < minDistance) {
+        minDistance = distance;
+        bestMatch = foodName;
+      }
+    }
+    
+    return bestMatch != null ? basicFoods[bestMatch] : null;
+  }
+
+  /// 編集距離（レーベンシュタイン距離）の計算
+  int _calculateEditDistance(String s1, String s2) {
+    final len1 = s1.length;
+    final len2 = s2.length;
+    
+    final matrix = List.generate(len1 + 1, (i) => List.filled(len2 + 1, 0));
+    
+    for (int i = 0; i <= len1; i++) matrix[i][0] = i;
+    for (int j = 0; j <= len2; j++) matrix[0][j] = j;
+    
+    for (int i = 1; i <= len1; i++) {
+      for (int j = 1; j <= len2; j++) {
+        final cost = s1[i - 1] == s2[j - 1] ? 0 : 1;
+        matrix[i][j] = [
+          matrix[i - 1][j] + 1,      // 削除
+          matrix[i][j - 1] + 1,      // 挿入  
+          matrix[i - 1][j - 1] + cost, // 置換
+        ].reduce((a, b) => a < b ? a : b);
+      }
+    }
+    
+    return matrix[len1][len2];
+  }
+
+  /// 基本食品データベースを取得
+  Map<String, JapaneseFoodCompositionTableData> _getBasicFoods() {
+    return {
+      '豚': JapaneseFoodCompositionTableData(
+        id: 1, groupId: 11, foodId: 11005, indexId: 1,
+        foodName: 'ぶた 肩ロース 脂身つき 生',
+        refuse: 0.0, enercKcal: 253.0, prot: 17.1, fat: 19.2, choavl: 0.2,
+        na: 54.0, k: 300.0, ca: 5.0, fe: 0.6, fib: 0.0, vitC: 1.0,
+        createdAt: DateTime.now(), updatedAt: DateTime.now(),
+      ),
+      // ... 他の食品データ
+    };
+  }
+  }
+
+  /// 材料リストをJSONに変換
+  String _ingredientsToJson(List<Ingredient> ingredients) {
+    final jsonList = ingredients.map((ingredient) => {
+      'name': ingredient.name,
+      'amount': ingredient.amount,
+      'unit': ingredient.unit,
+      'confidence': ingredient.confidence,
+    }).toList();
+    
+    return json.encode(jsonList);
+  }
+
+/// レシピ栄養分析結果
+class RecipeNutritionResult {
+  final List<Ingredient> ingredients;
+  final List<IngredientMatchResult> matchResults;
+  final RecipeNutrition nutrition;
+  final PFCBalance pfcBalance;
+  final Map<String, dynamic> extractionStats;
+  final String ingredientsJson;
+  final String rawText;
+
+  RecipeNutritionResult({
+    required this.ingredients,
+    required this.matchResults,
+    required this.nutrition,
+    required this.pfcBalance,
+    required this.extractionStats,
+    required this.ingredientsJson,
+    required this.rawText,
+  });
+}
+
+/// 材料マッチング結果
+class IngredientMatchResult {
+  final Ingredient ingredient;
+  final JapaneseFoodCompositionTableData? matchedFood;
+  final double confidence;
+
+  IngredientMatchResult({
+    required this.ingredient,
+    required this.matchedFood,
+    required this.confidence,
+  });
+}
+
+/// レシピ栄養情報
+class RecipeNutrition {
+  final double energy;
+  final double protein;
+  final double fat;
+  final double carbohydrate;
+  final double salt;
+  final double fiber;
+  final double vitaminC;
+
+  RecipeNutrition({
+    required this.energy,
+    required this.protein,
+    required this.fat,
+    required this.carbohydrate,
+    required this.salt,
+    required this.fiber,
+    required this.vitaminC,
+  });
+}
+
+/// PFCバランス
+class PFCBalance {
+  final double protein;
+  final double fat;
+  final double carbohydrate;
+
+  PFCBalance({
+    required this.protein,
+    required this.fat,
+    required this.carbohydrate,
+  });
+}
+

--- a/lib/data/datasources/app_database.dart
+++ b/lib/data/datasources/app_database.dart
@@ -9,6 +9,7 @@ import '../models/meal_table.dart';
 import '../models/personal_data_table.dart';
 import '../models/food_item_table.dart';
 import '../models/recipe_table.dart';
+import '../models/japanese_food_composition_table.dart';
 
 part 'app_database.g.dart';
 
@@ -20,12 +21,40 @@ part 'app_database.g.dart';
   PersonalDataTable,
   FoodItemTable,
   RecipeTable,
+  JapaneseFoodCompositionTable,
 ])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+  
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator m) async {
+      await m.createAll();
+    },
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from < 2) {
+        // バージョン1から2へのマイグレーション
+        // ExternalRecipeTableに新しいカラムを追加
+        await m.addColumn(externalRecipeTable, externalRecipeTable.ingredientsJson);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.ingredientsRawText);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.calories);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.protein);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.fat);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.carbohydrate);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.salt);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.fiber);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.vitaminC);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.isNutritionAutoExtracted);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.servings);
+        
+        // JapaneseFoodCompositionTableを作成
+        await m.createTable(japaneseFoodCompositionTable);
+      }
+    },
+  );
 
   /// 今日の栄養データを取得
   Future<Map<String, double>> getTodayNutrition() async {
@@ -138,6 +167,15 @@ class AppDatabase extends _$AppDatabase {
     required String title,
     String? tags,
     String? memo,
+    String? ingredientsRawText,
+    String? ingredientsJson,
+    double? calories,
+    double? protein,
+    double? fat,
+    double? carbohydrate,
+    double? salt,
+    double? fiber,
+    double? vitaminC,
   }) async {
     await (update(externalRecipeTable)
       ..where((tbl) => tbl.id.equals(recipeId)))
@@ -145,6 +183,15 @@ class AppDatabase extends _$AppDatabase {
         title: Value(title),
         tags: tags != null ? Value(tags) : const Value.absent(),
         memo: memo != null ? Value(memo) : const Value.absent(),
+        ingredientsRawText: ingredientsRawText != null ? Value(ingredientsRawText) : const Value.absent(),
+        ingredientsJson: ingredientsJson != null ? Value(ingredientsJson) : const Value.absent(),
+        calories: calories != null ? Value(calories) : const Value.absent(),
+        protein: protein != null ? Value(protein) : const Value.absent(),
+        fat: fat != null ? Value(fat) : const Value.absent(),
+        carbohydrate: carbohydrate != null ? Value(carbohydrate) : const Value.absent(),
+        salt: salt != null ? Value(salt) : const Value.absent(),
+        fiber: fiber != null ? Value(fiber) : const Value.absent(),
+        vitaminC: vitaminC != null ? Value(vitaminC) : const Value.absent(),
         updatedAt: Value(DateTime.now()),
       ));
   }

--- a/lib/data/datasources/app_database.g.dart
+++ b/lib/data/datasources/app_database.g.dart
@@ -596,6 +596,76 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
   late final GeneratedColumn<String> memo = GeneratedColumn<String>(
       'memo', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _ingredientsJsonMeta =
+      const VerificationMeta('ingredientsJson');
+  @override
+  late final GeneratedColumn<String> ingredientsJson = GeneratedColumn<String>(
+      'ingredients_json', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _ingredientsRawTextMeta =
+      const VerificationMeta('ingredientsRawText');
+  @override
+  late final GeneratedColumn<String> ingredientsRawText =
+      GeneratedColumn<String>('ingredients_raw_text', aliasedName, true,
+          type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _caloriesMeta =
+      const VerificationMeta('calories');
+  @override
+  late final GeneratedColumn<double> calories = GeneratedColumn<double>(
+      'calories', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _proteinMeta =
+      const VerificationMeta('protein');
+  @override
+  late final GeneratedColumn<double> protein = GeneratedColumn<double>(
+      'protein', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _fatMeta = const VerificationMeta('fat');
+  @override
+  late final GeneratedColumn<double> fat = GeneratedColumn<double>(
+      'fat', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _carbohydrateMeta =
+      const VerificationMeta('carbohydrate');
+  @override
+  late final GeneratedColumn<double> carbohydrate = GeneratedColumn<double>(
+      'carbohydrate', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _saltMeta = const VerificationMeta('salt');
+  @override
+  late final GeneratedColumn<double> salt = GeneratedColumn<double>(
+      'salt', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _fiberMeta = const VerificationMeta('fiber');
+  @override
+  late final GeneratedColumn<double> fiber = GeneratedColumn<double>(
+      'fiber', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitaminCMeta =
+      const VerificationMeta('vitaminC');
+  @override
+  late final GeneratedColumn<double> vitaminC = GeneratedColumn<double>(
+      'vitamin_c', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _isNutritionAutoExtractedMeta =
+      const VerificationMeta('isNutritionAutoExtracted');
+  @override
+  late final GeneratedColumn<bool> isNutritionAutoExtracted =
+      GeneratedColumn<bool>(
+          'is_nutrition_auto_extracted', aliasedName, false,
+          type: DriftSqlType.bool,
+          requiredDuringInsert: false,
+          defaultConstraints: GeneratedColumn.constraintIsAlways(
+              'CHECK ("is_nutrition_auto_extracted" IN (0, 1))'),
+          defaultValue: const Constant(false));
+  static const VerificationMeta _servingsMeta =
+      const VerificationMeta('servings');
+  @override
+  late final GeneratedColumn<int> servings = GeneratedColumn<int>(
+      'servings', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(1));
   static const VerificationMeta _lastAccessedAtMeta =
       const VerificationMeta('lastAccessedAt');
   @override
@@ -629,6 +699,17 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
         isFavorite,
         tags,
         memo,
+        ingredientsJson,
+        ingredientsRawText,
+        calories,
+        protein,
+        fat,
+        carbohydrate,
+        salt,
+        fiber,
+        vitaminC,
+        isNutritionAutoExtracted,
+        servings,
         lastAccessedAt,
         createdAt,
         updatedAt
@@ -687,6 +768,59 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
       context.handle(
           _memoMeta, memo.isAcceptableOrUnknown(data['memo']!, _memoMeta));
     }
+    if (data.containsKey('ingredients_json')) {
+      context.handle(
+          _ingredientsJsonMeta,
+          ingredientsJson.isAcceptableOrUnknown(
+              data['ingredients_json']!, _ingredientsJsonMeta));
+    }
+    if (data.containsKey('ingredients_raw_text')) {
+      context.handle(
+          _ingredientsRawTextMeta,
+          ingredientsRawText.isAcceptableOrUnknown(
+              data['ingredients_raw_text']!, _ingredientsRawTextMeta));
+    }
+    if (data.containsKey('calories')) {
+      context.handle(_caloriesMeta,
+          calories.isAcceptableOrUnknown(data['calories']!, _caloriesMeta));
+    }
+    if (data.containsKey('protein')) {
+      context.handle(_proteinMeta,
+          protein.isAcceptableOrUnknown(data['protein']!, _proteinMeta));
+    }
+    if (data.containsKey('fat')) {
+      context.handle(
+          _fatMeta, fat.isAcceptableOrUnknown(data['fat']!, _fatMeta));
+    }
+    if (data.containsKey('carbohydrate')) {
+      context.handle(
+          _carbohydrateMeta,
+          carbohydrate.isAcceptableOrUnknown(
+              data['carbohydrate']!, _carbohydrateMeta));
+    }
+    if (data.containsKey('salt')) {
+      context.handle(
+          _saltMeta, salt.isAcceptableOrUnknown(data['salt']!, _saltMeta));
+    }
+    if (data.containsKey('fiber')) {
+      context.handle(
+          _fiberMeta, fiber.isAcceptableOrUnknown(data['fiber']!, _fiberMeta));
+    }
+    if (data.containsKey('vitamin_c')) {
+      context.handle(_vitaminCMeta,
+          vitaminC.isAcceptableOrUnknown(data['vitamin_c']!, _vitaminCMeta));
+    }
+    if (data.containsKey('is_nutrition_auto_extracted')) {
+      context.handle(
+          _isNutritionAutoExtractedMeta,
+          isNutritionAutoExtracted.isAcceptableOrUnknown(
+              data['is_nutrition_auto_extracted']!,
+              _isNutritionAutoExtractedMeta));
+    }
+    if (data.containsKey('servings')) {
+      context.handle(_servingsMeta,
+          servings.isAcceptableOrUnknown(data['servings']!, _servingsMeta));
+    }
     if (data.containsKey('last_accessed_at')) {
       context.handle(
           _lastAccessedAtMeta,
@@ -729,6 +863,29 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
           .read(DriftSqlType.string, data['${effectivePrefix}tags']),
       memo: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}memo']),
+      ingredientsJson: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}ingredients_json']),
+      ingredientsRawText: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}ingredients_raw_text']),
+      calories: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}calories']),
+      protein: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}protein']),
+      fat: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fat']),
+      carbohydrate: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}carbohydrate']),
+      salt: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}salt']),
+      fiber: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fiber']),
+      vitaminC: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vitamin_c']),
+      isNutritionAutoExtracted: attachedDatabase.typeMapping.read(
+          DriftSqlType.bool,
+          data['${effectivePrefix}is_nutrition_auto_extracted'])!,
+      servings: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}servings'])!,
       lastAccessedAt: attachedDatabase.typeMapping.read(
           DriftSqlType.dateTime, data['${effectivePrefix}last_accessed_at']),
       createdAt: attachedDatabase.typeMapping
@@ -773,6 +930,39 @@ class ExternalRecipeTableData extends DataClass
   /// メモ
   final String? memo;
 
+  /// 材料情報（JSON形式）
+  final String? ingredientsJson;
+
+  /// 抽出された材料の生テキスト
+  final String? ingredientsRawText;
+
+  /// 栄養情報（カロリー/1人前）
+  final double? calories;
+
+  /// タンパク質（g/1人前）
+  final double? protein;
+
+  /// 脂質（g/1人前）
+  final double? fat;
+
+  /// 炭水化物（g/1人前）
+  final double? carbohydrate;
+
+  /// 食塩相当量（g/1人前）
+  final double? salt;
+
+  /// 食物繊維（g/1人前）
+  final double? fiber;
+
+  /// ビタミンC（mg/1人前）
+  final double? vitaminC;
+
+  /// 材料・栄養情報が自動推測されたかのフラグ
+  final bool isNutritionAutoExtracted;
+
+  /// 人数（栄養計算の基準）
+  final int servings;
+
   /// 最終アクセス日時
   final DateTime? lastAccessedAt;
 
@@ -791,6 +981,17 @@ class ExternalRecipeTableData extends DataClass
       required this.isFavorite,
       this.tags,
       this.memo,
+      this.ingredientsJson,
+      this.ingredientsRawText,
+      this.calories,
+      this.protein,
+      this.fat,
+      this.carbohydrate,
+      this.salt,
+      this.fiber,
+      this.vitaminC,
+      required this.isNutritionAutoExtracted,
+      required this.servings,
       this.lastAccessedAt,
       required this.createdAt,
       required this.updatedAt});
@@ -816,6 +1017,36 @@ class ExternalRecipeTableData extends DataClass
     if (!nullToAbsent || memo != null) {
       map['memo'] = Variable<String>(memo);
     }
+    if (!nullToAbsent || ingredientsJson != null) {
+      map['ingredients_json'] = Variable<String>(ingredientsJson);
+    }
+    if (!nullToAbsent || ingredientsRawText != null) {
+      map['ingredients_raw_text'] = Variable<String>(ingredientsRawText);
+    }
+    if (!nullToAbsent || calories != null) {
+      map['calories'] = Variable<double>(calories);
+    }
+    if (!nullToAbsent || protein != null) {
+      map['protein'] = Variable<double>(protein);
+    }
+    if (!nullToAbsent || fat != null) {
+      map['fat'] = Variable<double>(fat);
+    }
+    if (!nullToAbsent || carbohydrate != null) {
+      map['carbohydrate'] = Variable<double>(carbohydrate);
+    }
+    if (!nullToAbsent || salt != null) {
+      map['salt'] = Variable<double>(salt);
+    }
+    if (!nullToAbsent || fiber != null) {
+      map['fiber'] = Variable<double>(fiber);
+    }
+    if (!nullToAbsent || vitaminC != null) {
+      map['vitamin_c'] = Variable<double>(vitaminC);
+    }
+    map['is_nutrition_auto_extracted'] =
+        Variable<bool>(isNutritionAutoExtracted);
+    map['servings'] = Variable<int>(servings);
     if (!nullToAbsent || lastAccessedAt != null) {
       map['last_accessed_at'] = Variable<DateTime>(lastAccessedAt);
     }
@@ -841,6 +1072,30 @@ class ExternalRecipeTableData extends DataClass
       isFavorite: Value(isFavorite),
       tags: tags == null && nullToAbsent ? const Value.absent() : Value(tags),
       memo: memo == null && nullToAbsent ? const Value.absent() : Value(memo),
+      ingredientsJson: ingredientsJson == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ingredientsJson),
+      ingredientsRawText: ingredientsRawText == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ingredientsRawText),
+      calories: calories == null && nullToAbsent
+          ? const Value.absent()
+          : Value(calories),
+      protein: protein == null && nullToAbsent
+          ? const Value.absent()
+          : Value(protein),
+      fat: fat == null && nullToAbsent ? const Value.absent() : Value(fat),
+      carbohydrate: carbohydrate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(carbohydrate),
+      salt: salt == null && nullToAbsent ? const Value.absent() : Value(salt),
+      fiber:
+          fiber == null && nullToAbsent ? const Value.absent() : Value(fiber),
+      vitaminC: vitaminC == null && nullToAbsent
+          ? const Value.absent()
+          : Value(vitaminC),
+      isNutritionAutoExtracted: Value(isNutritionAutoExtracted),
+      servings: Value(servings),
       lastAccessedAt: lastAccessedAt == null && nullToAbsent
           ? const Value.absent()
           : Value(lastAccessedAt),
@@ -862,6 +1117,19 @@ class ExternalRecipeTableData extends DataClass
       isFavorite: serializer.fromJson<bool>(json['isFavorite']),
       tags: serializer.fromJson<String?>(json['tags']),
       memo: serializer.fromJson<String?>(json['memo']),
+      ingredientsJson: serializer.fromJson<String?>(json['ingredientsJson']),
+      ingredientsRawText:
+          serializer.fromJson<String?>(json['ingredientsRawText']),
+      calories: serializer.fromJson<double?>(json['calories']),
+      protein: serializer.fromJson<double?>(json['protein']),
+      fat: serializer.fromJson<double?>(json['fat']),
+      carbohydrate: serializer.fromJson<double?>(json['carbohydrate']),
+      salt: serializer.fromJson<double?>(json['salt']),
+      fiber: serializer.fromJson<double?>(json['fiber']),
+      vitaminC: serializer.fromJson<double?>(json['vitaminC']),
+      isNutritionAutoExtracted:
+          serializer.fromJson<bool>(json['isNutritionAutoExtracted']),
+      servings: serializer.fromJson<int>(json['servings']),
       lastAccessedAt: serializer.fromJson<DateTime?>(json['lastAccessedAt']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
@@ -880,6 +1148,18 @@ class ExternalRecipeTableData extends DataClass
       'isFavorite': serializer.toJson<bool>(isFavorite),
       'tags': serializer.toJson<String?>(tags),
       'memo': serializer.toJson<String?>(memo),
+      'ingredientsJson': serializer.toJson<String?>(ingredientsJson),
+      'ingredientsRawText': serializer.toJson<String?>(ingredientsRawText),
+      'calories': serializer.toJson<double?>(calories),
+      'protein': serializer.toJson<double?>(protein),
+      'fat': serializer.toJson<double?>(fat),
+      'carbohydrate': serializer.toJson<double?>(carbohydrate),
+      'salt': serializer.toJson<double?>(salt),
+      'fiber': serializer.toJson<double?>(fiber),
+      'vitaminC': serializer.toJson<double?>(vitaminC),
+      'isNutritionAutoExtracted':
+          serializer.toJson<bool>(isNutritionAutoExtracted),
+      'servings': serializer.toJson<int>(servings),
       'lastAccessedAt': serializer.toJson<DateTime?>(lastAccessedAt),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
@@ -896,6 +1176,17 @@ class ExternalRecipeTableData extends DataClass
           bool? isFavorite,
           Value<String?> tags = const Value.absent(),
           Value<String?> memo = const Value.absent(),
+          Value<String?> ingredientsJson = const Value.absent(),
+          Value<String?> ingredientsRawText = const Value.absent(),
+          Value<double?> calories = const Value.absent(),
+          Value<double?> protein = const Value.absent(),
+          Value<double?> fat = const Value.absent(),
+          Value<double?> carbohydrate = const Value.absent(),
+          Value<double?> salt = const Value.absent(),
+          Value<double?> fiber = const Value.absent(),
+          Value<double?> vitaminC = const Value.absent(),
+          bool? isNutritionAutoExtracted,
+          int? servings,
           Value<DateTime?> lastAccessedAt = const Value.absent(),
           DateTime? createdAt,
           DateTime? updatedAt}) =>
@@ -909,6 +1200,23 @@ class ExternalRecipeTableData extends DataClass
         isFavorite: isFavorite ?? this.isFavorite,
         tags: tags.present ? tags.value : this.tags,
         memo: memo.present ? memo.value : this.memo,
+        ingredientsJson: ingredientsJson.present
+            ? ingredientsJson.value
+            : this.ingredientsJson,
+        ingredientsRawText: ingredientsRawText.present
+            ? ingredientsRawText.value
+            : this.ingredientsRawText,
+        calories: calories.present ? calories.value : this.calories,
+        protein: protein.present ? protein.value : this.protein,
+        fat: fat.present ? fat.value : this.fat,
+        carbohydrate:
+            carbohydrate.present ? carbohydrate.value : this.carbohydrate,
+        salt: salt.present ? salt.value : this.salt,
+        fiber: fiber.present ? fiber.value : this.fiber,
+        vitaminC: vitaminC.present ? vitaminC.value : this.vitaminC,
+        isNutritionAutoExtracted:
+            isNutritionAutoExtracted ?? this.isNutritionAutoExtracted,
+        servings: servings ?? this.servings,
         lastAccessedAt:
             lastAccessedAt.present ? lastAccessedAt.value : this.lastAccessedAt,
         createdAt: createdAt ?? this.createdAt,
@@ -927,6 +1235,25 @@ class ExternalRecipeTableData extends DataClass
           data.isFavorite.present ? data.isFavorite.value : this.isFavorite,
       tags: data.tags.present ? data.tags.value : this.tags,
       memo: data.memo.present ? data.memo.value : this.memo,
+      ingredientsJson: data.ingredientsJson.present
+          ? data.ingredientsJson.value
+          : this.ingredientsJson,
+      ingredientsRawText: data.ingredientsRawText.present
+          ? data.ingredientsRawText.value
+          : this.ingredientsRawText,
+      calories: data.calories.present ? data.calories.value : this.calories,
+      protein: data.protein.present ? data.protein.value : this.protein,
+      fat: data.fat.present ? data.fat.value : this.fat,
+      carbohydrate: data.carbohydrate.present
+          ? data.carbohydrate.value
+          : this.carbohydrate,
+      salt: data.salt.present ? data.salt.value : this.salt,
+      fiber: data.fiber.present ? data.fiber.value : this.fiber,
+      vitaminC: data.vitaminC.present ? data.vitaminC.value : this.vitaminC,
+      isNutritionAutoExtracted: data.isNutritionAutoExtracted.present
+          ? data.isNutritionAutoExtracted.value
+          : this.isNutritionAutoExtracted,
+      servings: data.servings.present ? data.servings.value : this.servings,
       lastAccessedAt: data.lastAccessedAt.present
           ? data.lastAccessedAt.value
           : this.lastAccessedAt,
@@ -947,6 +1274,17 @@ class ExternalRecipeTableData extends DataClass
           ..write('isFavorite: $isFavorite, ')
           ..write('tags: $tags, ')
           ..write('memo: $memo, ')
+          ..write('ingredientsJson: $ingredientsJson, ')
+          ..write('ingredientsRawText: $ingredientsRawText, ')
+          ..write('calories: $calories, ')
+          ..write('protein: $protein, ')
+          ..write('fat: $fat, ')
+          ..write('carbohydrate: $carbohydrate, ')
+          ..write('salt: $salt, ')
+          ..write('fiber: $fiber, ')
+          ..write('vitaminC: $vitaminC, ')
+          ..write('isNutritionAutoExtracted: $isNutritionAutoExtracted, ')
+          ..write('servings: $servings, ')
           ..write('lastAccessedAt: $lastAccessedAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
@@ -955,8 +1293,31 @@ class ExternalRecipeTableData extends DataClass
   }
 
   @override
-  int get hashCode => Object.hash(id, url, title, description, imageUrl,
-      siteName, isFavorite, tags, memo, lastAccessedAt, createdAt, updatedAt);
+  int get hashCode => Object.hashAll([
+        id,
+        url,
+        title,
+        description,
+        imageUrl,
+        siteName,
+        isFavorite,
+        tags,
+        memo,
+        ingredientsJson,
+        ingredientsRawText,
+        calories,
+        protein,
+        fat,
+        carbohydrate,
+        salt,
+        fiber,
+        vitaminC,
+        isNutritionAutoExtracted,
+        servings,
+        lastAccessedAt,
+        createdAt,
+        updatedAt
+      ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -970,6 +1331,17 @@ class ExternalRecipeTableData extends DataClass
           other.isFavorite == this.isFavorite &&
           other.tags == this.tags &&
           other.memo == this.memo &&
+          other.ingredientsJson == this.ingredientsJson &&
+          other.ingredientsRawText == this.ingredientsRawText &&
+          other.calories == this.calories &&
+          other.protein == this.protein &&
+          other.fat == this.fat &&
+          other.carbohydrate == this.carbohydrate &&
+          other.salt == this.salt &&
+          other.fiber == this.fiber &&
+          other.vitaminC == this.vitaminC &&
+          other.isNutritionAutoExtracted == this.isNutritionAutoExtracted &&
+          other.servings == this.servings &&
           other.lastAccessedAt == this.lastAccessedAt &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
@@ -986,6 +1358,17 @@ class ExternalRecipeTableCompanion
   final Value<bool> isFavorite;
   final Value<String?> tags;
   final Value<String?> memo;
+  final Value<String?> ingredientsJson;
+  final Value<String?> ingredientsRawText;
+  final Value<double?> calories;
+  final Value<double?> protein;
+  final Value<double?> fat;
+  final Value<double?> carbohydrate;
+  final Value<double?> salt;
+  final Value<double?> fiber;
+  final Value<double?> vitaminC;
+  final Value<bool> isNutritionAutoExtracted;
+  final Value<int> servings;
   final Value<DateTime?> lastAccessedAt;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
@@ -999,6 +1382,17 @@ class ExternalRecipeTableCompanion
     this.isFavorite = const Value.absent(),
     this.tags = const Value.absent(),
     this.memo = const Value.absent(),
+    this.ingredientsJson = const Value.absent(),
+    this.ingredientsRawText = const Value.absent(),
+    this.calories = const Value.absent(),
+    this.protein = const Value.absent(),
+    this.fat = const Value.absent(),
+    this.carbohydrate = const Value.absent(),
+    this.salt = const Value.absent(),
+    this.fiber = const Value.absent(),
+    this.vitaminC = const Value.absent(),
+    this.isNutritionAutoExtracted = const Value.absent(),
+    this.servings = const Value.absent(),
     this.lastAccessedAt = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
@@ -1013,6 +1407,17 @@ class ExternalRecipeTableCompanion
     this.isFavorite = const Value.absent(),
     this.tags = const Value.absent(),
     this.memo = const Value.absent(),
+    this.ingredientsJson = const Value.absent(),
+    this.ingredientsRawText = const Value.absent(),
+    this.calories = const Value.absent(),
+    this.protein = const Value.absent(),
+    this.fat = const Value.absent(),
+    this.carbohydrate = const Value.absent(),
+    this.salt = const Value.absent(),
+    this.fiber = const Value.absent(),
+    this.vitaminC = const Value.absent(),
+    this.isNutritionAutoExtracted = const Value.absent(),
+    this.servings = const Value.absent(),
     this.lastAccessedAt = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
@@ -1028,6 +1433,17 @@ class ExternalRecipeTableCompanion
     Expression<bool>? isFavorite,
     Expression<String>? tags,
     Expression<String>? memo,
+    Expression<String>? ingredientsJson,
+    Expression<String>? ingredientsRawText,
+    Expression<double>? calories,
+    Expression<double>? protein,
+    Expression<double>? fat,
+    Expression<double>? carbohydrate,
+    Expression<double>? salt,
+    Expression<double>? fiber,
+    Expression<double>? vitaminC,
+    Expression<bool>? isNutritionAutoExtracted,
+    Expression<int>? servings,
     Expression<DateTime>? lastAccessedAt,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
@@ -1042,6 +1458,19 @@ class ExternalRecipeTableCompanion
       if (isFavorite != null) 'is_favorite': isFavorite,
       if (tags != null) 'tags': tags,
       if (memo != null) 'memo': memo,
+      if (ingredientsJson != null) 'ingredients_json': ingredientsJson,
+      if (ingredientsRawText != null)
+        'ingredients_raw_text': ingredientsRawText,
+      if (calories != null) 'calories': calories,
+      if (protein != null) 'protein': protein,
+      if (fat != null) 'fat': fat,
+      if (carbohydrate != null) 'carbohydrate': carbohydrate,
+      if (salt != null) 'salt': salt,
+      if (fiber != null) 'fiber': fiber,
+      if (vitaminC != null) 'vitamin_c': vitaminC,
+      if (isNutritionAutoExtracted != null)
+        'is_nutrition_auto_extracted': isNutritionAutoExtracted,
+      if (servings != null) 'servings': servings,
       if (lastAccessedAt != null) 'last_accessed_at': lastAccessedAt,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
@@ -1058,6 +1487,17 @@ class ExternalRecipeTableCompanion
       Value<bool>? isFavorite,
       Value<String?>? tags,
       Value<String?>? memo,
+      Value<String?>? ingredientsJson,
+      Value<String?>? ingredientsRawText,
+      Value<double?>? calories,
+      Value<double?>? protein,
+      Value<double?>? fat,
+      Value<double?>? carbohydrate,
+      Value<double?>? salt,
+      Value<double?>? fiber,
+      Value<double?>? vitaminC,
+      Value<bool>? isNutritionAutoExtracted,
+      Value<int>? servings,
       Value<DateTime?>? lastAccessedAt,
       Value<DateTime>? createdAt,
       Value<DateTime>? updatedAt}) {
@@ -1071,6 +1511,18 @@ class ExternalRecipeTableCompanion
       isFavorite: isFavorite ?? this.isFavorite,
       tags: tags ?? this.tags,
       memo: memo ?? this.memo,
+      ingredientsJson: ingredientsJson ?? this.ingredientsJson,
+      ingredientsRawText: ingredientsRawText ?? this.ingredientsRawText,
+      calories: calories ?? this.calories,
+      protein: protein ?? this.protein,
+      fat: fat ?? this.fat,
+      carbohydrate: carbohydrate ?? this.carbohydrate,
+      salt: salt ?? this.salt,
+      fiber: fiber ?? this.fiber,
+      vitaminC: vitaminC ?? this.vitaminC,
+      isNutritionAutoExtracted:
+          isNutritionAutoExtracted ?? this.isNutritionAutoExtracted,
+      servings: servings ?? this.servings,
       lastAccessedAt: lastAccessedAt ?? this.lastAccessedAt,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -1107,6 +1559,40 @@ class ExternalRecipeTableCompanion
     if (memo.present) {
       map['memo'] = Variable<String>(memo.value);
     }
+    if (ingredientsJson.present) {
+      map['ingredients_json'] = Variable<String>(ingredientsJson.value);
+    }
+    if (ingredientsRawText.present) {
+      map['ingredients_raw_text'] = Variable<String>(ingredientsRawText.value);
+    }
+    if (calories.present) {
+      map['calories'] = Variable<double>(calories.value);
+    }
+    if (protein.present) {
+      map['protein'] = Variable<double>(protein.value);
+    }
+    if (fat.present) {
+      map['fat'] = Variable<double>(fat.value);
+    }
+    if (carbohydrate.present) {
+      map['carbohydrate'] = Variable<double>(carbohydrate.value);
+    }
+    if (salt.present) {
+      map['salt'] = Variable<double>(salt.value);
+    }
+    if (fiber.present) {
+      map['fiber'] = Variable<double>(fiber.value);
+    }
+    if (vitaminC.present) {
+      map['vitamin_c'] = Variable<double>(vitaminC.value);
+    }
+    if (isNutritionAutoExtracted.present) {
+      map['is_nutrition_auto_extracted'] =
+          Variable<bool>(isNutritionAutoExtracted.value);
+    }
+    if (servings.present) {
+      map['servings'] = Variable<int>(servings.value);
+    }
     if (lastAccessedAt.present) {
       map['last_accessed_at'] = Variable<DateTime>(lastAccessedAt.value);
     }
@@ -1131,6 +1617,17 @@ class ExternalRecipeTableCompanion
           ..write('isFavorite: $isFavorite, ')
           ..write('tags: $tags, ')
           ..write('memo: $memo, ')
+          ..write('ingredientsJson: $ingredientsJson, ')
+          ..write('ingredientsRawText: $ingredientsRawText, ')
+          ..write('calories: $calories, ')
+          ..write('protein: $protein, ')
+          ..write('fat: $fat, ')
+          ..write('carbohydrate: $carbohydrate, ')
+          ..write('salt: $salt, ')
+          ..write('fiber: $fiber, ')
+          ..write('vitaminC: $vitaminC, ')
+          ..write('isNutritionAutoExtracted: $isNutritionAutoExtracted, ')
+          ..write('servings: $servings, ')
           ..write('lastAccessedAt: $lastAccessedAt, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
@@ -3716,6 +4213,1501 @@ class RecipeTableCompanion extends UpdateCompanion<RecipeTableData> {
   }
 }
 
+class $JapaneseFoodCompositionTableTable extends JapaneseFoodCompositionTable
+    with
+        TableInfo<$JapaneseFoodCompositionTableTable,
+            JapaneseFoodCompositionTableData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $JapaneseFoodCompositionTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _groupIdMeta =
+      const VerificationMeta('groupId');
+  @override
+  late final GeneratedColumn<int> groupId = GeneratedColumn<int>(
+      'group_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _foodIdMeta = const VerificationMeta('foodId');
+  @override
+  late final GeneratedColumn<int> foodId = GeneratedColumn<int>(
+      'food_id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _indexIdMeta =
+      const VerificationMeta('indexId');
+  @override
+  late final GeneratedColumn<int> indexId = GeneratedColumn<int>(
+      'index_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _foodNameMeta =
+      const VerificationMeta('foodName');
+  @override
+  late final GeneratedColumn<String> foodName = GeneratedColumn<String>(
+      'food_name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _refuseMeta = const VerificationMeta('refuse');
+  @override
+  late final GeneratedColumn<double> refuse = GeneratedColumn<double>(
+      'refuse', aliasedName, false,
+      type: DriftSqlType.double,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0.0));
+  static const VerificationMeta _enercMeta = const VerificationMeta('enerc');
+  @override
+  late final GeneratedColumn<double> enerc = GeneratedColumn<double>(
+      'enerc', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _enercKcalMeta =
+      const VerificationMeta('enercKcal');
+  @override
+  late final GeneratedColumn<double> enercKcal = GeneratedColumn<double>(
+      'enerc_kcal', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _waterMeta = const VerificationMeta('water');
+  @override
+  late final GeneratedColumn<double> water = GeneratedColumn<double>(
+      'water', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _protcaaMeta =
+      const VerificationMeta('protcaa');
+  @override
+  late final GeneratedColumn<double> protcaa = GeneratedColumn<double>(
+      'protcaa', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _protMeta = const VerificationMeta('prot');
+  @override
+  late final GeneratedColumn<double> prot = GeneratedColumn<double>(
+      'prot', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _fatnleaMeta =
+      const VerificationMeta('fatnlea');
+  @override
+  late final GeneratedColumn<double> fatnlea = GeneratedColumn<double>(
+      'fatnlea', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _choleMeta = const VerificationMeta('chole');
+  @override
+  late final GeneratedColumn<double> chole = GeneratedColumn<double>(
+      'chole', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _fatMeta = const VerificationMeta('fat');
+  @override
+  late final GeneratedColumn<double> fat = GeneratedColumn<double>(
+      'fat', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _choavlmMeta =
+      const VerificationMeta('choavlm');
+  @override
+  late final GeneratedColumn<double> choavlm = GeneratedColumn<double>(
+      'choavlm', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _choavlMeta = const VerificationMeta('choavl');
+  @override
+  late final GeneratedColumn<double> choavl = GeneratedColumn<double>(
+      'choavl', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _choavldfMeta =
+      const VerificationMeta('choavldf');
+  @override
+  late final GeneratedColumn<double> choavldf = GeneratedColumn<double>(
+      'choavldf', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _fibMeta = const VerificationMeta('fib');
+  @override
+  late final GeneratedColumn<double> fib = GeneratedColumn<double>(
+      'fib', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _polylMeta = const VerificationMeta('polyl');
+  @override
+  late final GeneratedColumn<double> polyl = GeneratedColumn<double>(
+      'polyl', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _chocdfMeta = const VerificationMeta('chocdf');
+  @override
+  late final GeneratedColumn<double> chocdf = GeneratedColumn<double>(
+      'chocdf', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _oaMeta = const VerificationMeta('oa');
+  @override
+  late final GeneratedColumn<double> oa = GeneratedColumn<double>(
+      'oa', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _ashMeta = const VerificationMeta('ash');
+  @override
+  late final GeneratedColumn<double> ash = GeneratedColumn<double>(
+      'ash', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _naMeta = const VerificationMeta('na');
+  @override
+  late final GeneratedColumn<double> na = GeneratedColumn<double>(
+      'na', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _kMeta = const VerificationMeta('k');
+  @override
+  late final GeneratedColumn<double> k = GeneratedColumn<double>(
+      'k', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _caMeta = const VerificationMeta('ca');
+  @override
+  late final GeneratedColumn<double> ca = GeneratedColumn<double>(
+      'ca', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _mgMeta = const VerificationMeta('mg');
+  @override
+  late final GeneratedColumn<double> mg = GeneratedColumn<double>(
+      'mg', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _pMeta = const VerificationMeta('p');
+  @override
+  late final GeneratedColumn<double> p = GeneratedColumn<double>(
+      'p', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _feMeta = const VerificationMeta('fe');
+  @override
+  late final GeneratedColumn<double> fe = GeneratedColumn<double>(
+      'fe', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _znMeta = const VerificationMeta('zn');
+  @override
+  late final GeneratedColumn<double> zn = GeneratedColumn<double>(
+      'zn', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _cuMeta = const VerificationMeta('cu');
+  @override
+  late final GeneratedColumn<double> cu = GeneratedColumn<double>(
+      'cu', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _mnMeta = const VerificationMeta('mn');
+  @override
+  late final GeneratedColumn<double> mn = GeneratedColumn<double>(
+      'mn', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _iodineMeta = const VerificationMeta('iodine');
+  @override
+  late final GeneratedColumn<double> iodine = GeneratedColumn<double>(
+      'iodine', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _seMeta = const VerificationMeta('se');
+  @override
+  late final GeneratedColumn<double> se = GeneratedColumn<double>(
+      'se', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _crMeta = const VerificationMeta('cr');
+  @override
+  late final GeneratedColumn<double> cr = GeneratedColumn<double>(
+      'cr', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _moMeta = const VerificationMeta('mo');
+  @override
+  late final GeneratedColumn<double> mo = GeneratedColumn<double>(
+      'mo', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _retolMeta = const VerificationMeta('retol');
+  @override
+  late final GeneratedColumn<double> retol = GeneratedColumn<double>(
+      'retol', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _cartaMeta = const VerificationMeta('carta');
+  @override
+  late final GeneratedColumn<double> carta = GeneratedColumn<double>(
+      'carta', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _cartbMeta = const VerificationMeta('cartb');
+  @override
+  late final GeneratedColumn<double> cartb = GeneratedColumn<double>(
+      'cartb', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _crypxbMeta = const VerificationMeta('crypxb');
+  @override
+  late final GeneratedColumn<double> crypxb = GeneratedColumn<double>(
+      'crypxb', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _cartbeqMeta =
+      const VerificationMeta('cartbeq');
+  @override
+  late final GeneratedColumn<double> cartbeq = GeneratedColumn<double>(
+      'cartbeq', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitaRaeMeta =
+      const VerificationMeta('vitaRae');
+  @override
+  late final GeneratedColumn<double> vitaRae = GeneratedColumn<double>(
+      'vita_rae', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitDMeta = const VerificationMeta('vitD');
+  @override
+  late final GeneratedColumn<double> vitD = GeneratedColumn<double>(
+      'vit_d', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _tocphAMeta = const VerificationMeta('tocphA');
+  @override
+  late final GeneratedColumn<double> tocphA = GeneratedColumn<double>(
+      'tocph_a', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _tocphBMeta = const VerificationMeta('tocphB');
+  @override
+  late final GeneratedColumn<double> tocphB = GeneratedColumn<double>(
+      'tocph_b', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _tocphGMeta = const VerificationMeta('tocphG');
+  @override
+  late final GeneratedColumn<double> tocphG = GeneratedColumn<double>(
+      'tocph_g', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _tocphDMeta = const VerificationMeta('tocphD');
+  @override
+  late final GeneratedColumn<double> tocphD = GeneratedColumn<double>(
+      'tocph_d', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitKMeta = const VerificationMeta('vitK');
+  @override
+  late final GeneratedColumn<double> vitK = GeneratedColumn<double>(
+      'vit_k', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _thiaMeta = const VerificationMeta('thia');
+  @override
+  late final GeneratedColumn<double> thia = GeneratedColumn<double>(
+      'thia', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _ribfMeta = const VerificationMeta('ribf');
+  @override
+  late final GeneratedColumn<double> ribf = GeneratedColumn<double>(
+      'ribf', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _niaMeta = const VerificationMeta('nia');
+  @override
+  late final GeneratedColumn<double> nia = GeneratedColumn<double>(
+      'nia', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _neMeta = const VerificationMeta('ne');
+  @override
+  late final GeneratedColumn<double> ne = GeneratedColumn<double>(
+      'ne', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitB6AMeta = const VerificationMeta('vitB6A');
+  @override
+  late final GeneratedColumn<double> vitB6A = GeneratedColumn<double>(
+      'vit_b6_a', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitB12Meta = const VerificationMeta('vitB12');
+  @override
+  late final GeneratedColumn<double> vitB12 = GeneratedColumn<double>(
+      'vit_b12', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _folMeta = const VerificationMeta('fol');
+  @override
+  late final GeneratedColumn<double> fol = GeneratedColumn<double>(
+      'fol', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _pantacMeta = const VerificationMeta('pantac');
+  @override
+  late final GeneratedColumn<double> pantac = GeneratedColumn<double>(
+      'pantac', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _biotMeta = const VerificationMeta('biot');
+  @override
+  late final GeneratedColumn<double> biot = GeneratedColumn<double>(
+      'biot', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _vitCMeta = const VerificationMeta('vitC');
+  @override
+  late final GeneratedColumn<double> vitC = GeneratedColumn<double>(
+      'vit_c', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _alcMeta = const VerificationMeta('alc');
+  @override
+  late final GeneratedColumn<double> alc = GeneratedColumn<double>(
+      'alc', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _naclEqMeta = const VerificationMeta('naclEq');
+  @override
+  late final GeneratedColumn<double> naclEq = GeneratedColumn<double>(
+      'nacl_eq', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        groupId,
+        foodId,
+        indexId,
+        foodName,
+        refuse,
+        enerc,
+        enercKcal,
+        water,
+        protcaa,
+        prot,
+        fatnlea,
+        chole,
+        fat,
+        choavlm,
+        choavl,
+        choavldf,
+        fib,
+        polyl,
+        chocdf,
+        oa,
+        ash,
+        na,
+        k,
+        ca,
+        mg,
+        p,
+        fe,
+        zn,
+        cu,
+        mn,
+        iodine,
+        se,
+        cr,
+        mo,
+        retol,
+        carta,
+        cartb,
+        crypxb,
+        cartbeq,
+        vitaRae,
+        vitD,
+        tocphA,
+        tocphB,
+        tocphG,
+        tocphD,
+        vitK,
+        thia,
+        ribf,
+        nia,
+        ne,
+        vitB6A,
+        vitB12,
+        fol,
+        pantac,
+        biot,
+        vitC,
+        alc,
+        naclEq,
+        createdAt,
+        updatedAt
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'japanese_food_composition_table';
+  @override
+  VerificationContext validateIntegrity(
+      Insertable<JapaneseFoodCompositionTableData> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('group_id')) {
+      context.handle(_groupIdMeta,
+          groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta));
+    } else if (isInserting) {
+      context.missing(_groupIdMeta);
+    }
+    if (data.containsKey('food_id')) {
+      context.handle(_foodIdMeta,
+          foodId.isAcceptableOrUnknown(data['food_id']!, _foodIdMeta));
+    } else if (isInserting) {
+      context.missing(_foodIdMeta);
+    }
+    if (data.containsKey('index_id')) {
+      context.handle(_indexIdMeta,
+          indexId.isAcceptableOrUnknown(data['index_id']!, _indexIdMeta));
+    } else if (isInserting) {
+      context.missing(_indexIdMeta);
+    }
+    if (data.containsKey('food_name')) {
+      context.handle(_foodNameMeta,
+          foodName.isAcceptableOrUnknown(data['food_name']!, _foodNameMeta));
+    } else if (isInserting) {
+      context.missing(_foodNameMeta);
+    }
+    if (data.containsKey('refuse')) {
+      context.handle(_refuseMeta,
+          refuse.isAcceptableOrUnknown(data['refuse']!, _refuseMeta));
+    }
+    if (data.containsKey('enerc')) {
+      context.handle(
+          _enercMeta, enerc.isAcceptableOrUnknown(data['enerc']!, _enercMeta));
+    }
+    if (data.containsKey('enerc_kcal')) {
+      context.handle(_enercKcalMeta,
+          enercKcal.isAcceptableOrUnknown(data['enerc_kcal']!, _enercKcalMeta));
+    }
+    if (data.containsKey('water')) {
+      context.handle(
+          _waterMeta, water.isAcceptableOrUnknown(data['water']!, _waterMeta));
+    }
+    if (data.containsKey('protcaa')) {
+      context.handle(_protcaaMeta,
+          protcaa.isAcceptableOrUnknown(data['protcaa']!, _protcaaMeta));
+    }
+    if (data.containsKey('prot')) {
+      context.handle(
+          _protMeta, prot.isAcceptableOrUnknown(data['prot']!, _protMeta));
+    }
+    if (data.containsKey('fatnlea')) {
+      context.handle(_fatnleaMeta,
+          fatnlea.isAcceptableOrUnknown(data['fatnlea']!, _fatnleaMeta));
+    }
+    if (data.containsKey('chole')) {
+      context.handle(
+          _choleMeta, chole.isAcceptableOrUnknown(data['chole']!, _choleMeta));
+    }
+    if (data.containsKey('fat')) {
+      context.handle(
+          _fatMeta, fat.isAcceptableOrUnknown(data['fat']!, _fatMeta));
+    }
+    if (data.containsKey('choavlm')) {
+      context.handle(_choavlmMeta,
+          choavlm.isAcceptableOrUnknown(data['choavlm']!, _choavlmMeta));
+    }
+    if (data.containsKey('choavl')) {
+      context.handle(_choavlMeta,
+          choavl.isAcceptableOrUnknown(data['choavl']!, _choavlMeta));
+    }
+    if (data.containsKey('choavldf')) {
+      context.handle(_choavldfMeta,
+          choavldf.isAcceptableOrUnknown(data['choavldf']!, _choavldfMeta));
+    }
+    if (data.containsKey('fib')) {
+      context.handle(
+          _fibMeta, fib.isAcceptableOrUnknown(data['fib']!, _fibMeta));
+    }
+    if (data.containsKey('polyl')) {
+      context.handle(
+          _polylMeta, polyl.isAcceptableOrUnknown(data['polyl']!, _polylMeta));
+    }
+    if (data.containsKey('chocdf')) {
+      context.handle(_chocdfMeta,
+          chocdf.isAcceptableOrUnknown(data['chocdf']!, _chocdfMeta));
+    }
+    if (data.containsKey('oa')) {
+      context.handle(_oaMeta, oa.isAcceptableOrUnknown(data['oa']!, _oaMeta));
+    }
+    if (data.containsKey('ash')) {
+      context.handle(
+          _ashMeta, ash.isAcceptableOrUnknown(data['ash']!, _ashMeta));
+    }
+    if (data.containsKey('na')) {
+      context.handle(_naMeta, na.isAcceptableOrUnknown(data['na']!, _naMeta));
+    }
+    if (data.containsKey('k')) {
+      context.handle(_kMeta, k.isAcceptableOrUnknown(data['k']!, _kMeta));
+    }
+    if (data.containsKey('ca')) {
+      context.handle(_caMeta, ca.isAcceptableOrUnknown(data['ca']!, _caMeta));
+    }
+    if (data.containsKey('mg')) {
+      context.handle(_mgMeta, mg.isAcceptableOrUnknown(data['mg']!, _mgMeta));
+    }
+    if (data.containsKey('p')) {
+      context.handle(_pMeta, p.isAcceptableOrUnknown(data['p']!, _pMeta));
+    }
+    if (data.containsKey('fe')) {
+      context.handle(_feMeta, fe.isAcceptableOrUnknown(data['fe']!, _feMeta));
+    }
+    if (data.containsKey('zn')) {
+      context.handle(_znMeta, zn.isAcceptableOrUnknown(data['zn']!, _znMeta));
+    }
+    if (data.containsKey('cu')) {
+      context.handle(_cuMeta, cu.isAcceptableOrUnknown(data['cu']!, _cuMeta));
+    }
+    if (data.containsKey('mn')) {
+      context.handle(_mnMeta, mn.isAcceptableOrUnknown(data['mn']!, _mnMeta));
+    }
+    if (data.containsKey('iodine')) {
+      context.handle(_iodineMeta,
+          iodine.isAcceptableOrUnknown(data['iodine']!, _iodineMeta));
+    }
+    if (data.containsKey('se')) {
+      context.handle(_seMeta, se.isAcceptableOrUnknown(data['se']!, _seMeta));
+    }
+    if (data.containsKey('cr')) {
+      context.handle(_crMeta, cr.isAcceptableOrUnknown(data['cr']!, _crMeta));
+    }
+    if (data.containsKey('mo')) {
+      context.handle(_moMeta, mo.isAcceptableOrUnknown(data['mo']!, _moMeta));
+    }
+    if (data.containsKey('retol')) {
+      context.handle(
+          _retolMeta, retol.isAcceptableOrUnknown(data['retol']!, _retolMeta));
+    }
+    if (data.containsKey('carta')) {
+      context.handle(
+          _cartaMeta, carta.isAcceptableOrUnknown(data['carta']!, _cartaMeta));
+    }
+    if (data.containsKey('cartb')) {
+      context.handle(
+          _cartbMeta, cartb.isAcceptableOrUnknown(data['cartb']!, _cartbMeta));
+    }
+    if (data.containsKey('crypxb')) {
+      context.handle(_crypxbMeta,
+          crypxb.isAcceptableOrUnknown(data['crypxb']!, _crypxbMeta));
+    }
+    if (data.containsKey('cartbeq')) {
+      context.handle(_cartbeqMeta,
+          cartbeq.isAcceptableOrUnknown(data['cartbeq']!, _cartbeqMeta));
+    }
+    if (data.containsKey('vita_rae')) {
+      context.handle(_vitaRaeMeta,
+          vitaRae.isAcceptableOrUnknown(data['vita_rae']!, _vitaRaeMeta));
+    }
+    if (data.containsKey('vit_d')) {
+      context.handle(
+          _vitDMeta, vitD.isAcceptableOrUnknown(data['vit_d']!, _vitDMeta));
+    }
+    if (data.containsKey('tocph_a')) {
+      context.handle(_tocphAMeta,
+          tocphA.isAcceptableOrUnknown(data['tocph_a']!, _tocphAMeta));
+    }
+    if (data.containsKey('tocph_b')) {
+      context.handle(_tocphBMeta,
+          tocphB.isAcceptableOrUnknown(data['tocph_b']!, _tocphBMeta));
+    }
+    if (data.containsKey('tocph_g')) {
+      context.handle(_tocphGMeta,
+          tocphG.isAcceptableOrUnknown(data['tocph_g']!, _tocphGMeta));
+    }
+    if (data.containsKey('tocph_d')) {
+      context.handle(_tocphDMeta,
+          tocphD.isAcceptableOrUnknown(data['tocph_d']!, _tocphDMeta));
+    }
+    if (data.containsKey('vit_k')) {
+      context.handle(
+          _vitKMeta, vitK.isAcceptableOrUnknown(data['vit_k']!, _vitKMeta));
+    }
+    if (data.containsKey('thia')) {
+      context.handle(
+          _thiaMeta, thia.isAcceptableOrUnknown(data['thia']!, _thiaMeta));
+    }
+    if (data.containsKey('ribf')) {
+      context.handle(
+          _ribfMeta, ribf.isAcceptableOrUnknown(data['ribf']!, _ribfMeta));
+    }
+    if (data.containsKey('nia')) {
+      context.handle(
+          _niaMeta, nia.isAcceptableOrUnknown(data['nia']!, _niaMeta));
+    }
+    if (data.containsKey('ne')) {
+      context.handle(_neMeta, ne.isAcceptableOrUnknown(data['ne']!, _neMeta));
+    }
+    if (data.containsKey('vit_b6_a')) {
+      context.handle(_vitB6AMeta,
+          vitB6A.isAcceptableOrUnknown(data['vit_b6_a']!, _vitB6AMeta));
+    }
+    if (data.containsKey('vit_b12')) {
+      context.handle(_vitB12Meta,
+          vitB12.isAcceptableOrUnknown(data['vit_b12']!, _vitB12Meta));
+    }
+    if (data.containsKey('fol')) {
+      context.handle(
+          _folMeta, fol.isAcceptableOrUnknown(data['fol']!, _folMeta));
+    }
+    if (data.containsKey('pantac')) {
+      context.handle(_pantacMeta,
+          pantac.isAcceptableOrUnknown(data['pantac']!, _pantacMeta));
+    }
+    if (data.containsKey('biot')) {
+      context.handle(
+          _biotMeta, biot.isAcceptableOrUnknown(data['biot']!, _biotMeta));
+    }
+    if (data.containsKey('vit_c')) {
+      context.handle(
+          _vitCMeta, vitC.isAcceptableOrUnknown(data['vit_c']!, _vitCMeta));
+    }
+    if (data.containsKey('alc')) {
+      context.handle(
+          _alcMeta, alc.isAcceptableOrUnknown(data['alc']!, _alcMeta));
+    }
+    if (data.containsKey('nacl_eq')) {
+      context.handle(_naclEqMeta,
+          naclEq.isAcceptableOrUnknown(data['nacl_eq']!, _naclEqMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  JapaneseFoodCompositionTableData map(Map<String, dynamic> data,
+      {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return JapaneseFoodCompositionTableData(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      groupId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}group_id'])!,
+      foodId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}food_id'])!,
+      indexId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}index_id'])!,
+      foodName: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}food_name'])!,
+      refuse: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}refuse'])!,
+      enerc: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}enerc']),
+      enercKcal: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}enerc_kcal']),
+      water: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}water']),
+      protcaa: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}protcaa']),
+      prot: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}prot']),
+      fatnlea: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fatnlea']),
+      chole: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}chole']),
+      fat: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fat']),
+      choavlm: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}choavlm']),
+      choavl: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}choavl']),
+      choavldf: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}choavldf']),
+      fib: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fib']),
+      polyl: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}polyl']),
+      chocdf: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}chocdf']),
+      oa: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}oa']),
+      ash: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}ash']),
+      na: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}na']),
+      k: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}k']),
+      ca: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}ca']),
+      mg: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}mg']),
+      p: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}p']),
+      fe: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fe']),
+      zn: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}zn']),
+      cu: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}cu']),
+      mn: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}mn']),
+      iodine: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}iodine']),
+      se: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}se']),
+      cr: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}cr']),
+      mo: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}mo']),
+      retol: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}retol']),
+      carta: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}carta']),
+      cartb: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}cartb']),
+      crypxb: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}crypxb']),
+      cartbeq: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}cartbeq']),
+      vitaRae: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vita_rae']),
+      vitD: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vit_d']),
+      tocphA: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}tocph_a']),
+      tocphB: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}tocph_b']),
+      tocphG: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}tocph_g']),
+      tocphD: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}tocph_d']),
+      vitK: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vit_k']),
+      thia: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}thia']),
+      ribf: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}ribf']),
+      nia: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}nia']),
+      ne: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}ne']),
+      vitB6A: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vit_b6_a']),
+      vitB12: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vit_b12']),
+      fol: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}fol']),
+      pantac: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}pantac']),
+      biot: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}biot']),
+      vitC: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}vit_c']),
+      alc: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}alc']),
+      naclEq: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}nacl_eq']),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+    );
+  }
+
+  @override
+  $JapaneseFoodCompositionTableTable createAlias(String alias) {
+    return $JapaneseFoodCompositionTableTable(attachedDatabase, alias);
+  }
+}
+
+class JapaneseFoodCompositionTableCompanion
+    extends UpdateCompanion<JapaneseFoodCompositionTableData> {
+  final Value<int> id;
+  final Value<int> groupId;
+  final Value<int> foodId;
+  final Value<int> indexId;
+  final Value<String> foodName;
+  final Value<double> refuse;
+  final Value<double?> enerc;
+  final Value<double?> enercKcal;
+  final Value<double?> water;
+  final Value<double?> protcaa;
+  final Value<double?> prot;
+  final Value<double?> fatnlea;
+  final Value<double?> chole;
+  final Value<double?> fat;
+  final Value<double?> choavlm;
+  final Value<double?> choavl;
+  final Value<double?> choavldf;
+  final Value<double?> fib;
+  final Value<double?> polyl;
+  final Value<double?> chocdf;
+  final Value<double?> oa;
+  final Value<double?> ash;
+  final Value<double?> na;
+  final Value<double?> k;
+  final Value<double?> ca;
+  final Value<double?> mg;
+  final Value<double?> p;
+  final Value<double?> fe;
+  final Value<double?> zn;
+  final Value<double?> cu;
+  final Value<double?> mn;
+  final Value<double?> iodine;
+  final Value<double?> se;
+  final Value<double?> cr;
+  final Value<double?> mo;
+  final Value<double?> retol;
+  final Value<double?> carta;
+  final Value<double?> cartb;
+  final Value<double?> crypxb;
+  final Value<double?> cartbeq;
+  final Value<double?> vitaRae;
+  final Value<double?> vitD;
+  final Value<double?> tocphA;
+  final Value<double?> tocphB;
+  final Value<double?> tocphG;
+  final Value<double?> tocphD;
+  final Value<double?> vitK;
+  final Value<double?> thia;
+  final Value<double?> ribf;
+  final Value<double?> nia;
+  final Value<double?> ne;
+  final Value<double?> vitB6A;
+  final Value<double?> vitB12;
+  final Value<double?> fol;
+  final Value<double?> pantac;
+  final Value<double?> biot;
+  final Value<double?> vitC;
+  final Value<double?> alc;
+  final Value<double?> naclEq;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  const JapaneseFoodCompositionTableCompanion({
+    this.id = const Value.absent(),
+    this.groupId = const Value.absent(),
+    this.foodId = const Value.absent(),
+    this.indexId = const Value.absent(),
+    this.foodName = const Value.absent(),
+    this.refuse = const Value.absent(),
+    this.enerc = const Value.absent(),
+    this.enercKcal = const Value.absent(),
+    this.water = const Value.absent(),
+    this.protcaa = const Value.absent(),
+    this.prot = const Value.absent(),
+    this.fatnlea = const Value.absent(),
+    this.chole = const Value.absent(),
+    this.fat = const Value.absent(),
+    this.choavlm = const Value.absent(),
+    this.choavl = const Value.absent(),
+    this.choavldf = const Value.absent(),
+    this.fib = const Value.absent(),
+    this.polyl = const Value.absent(),
+    this.chocdf = const Value.absent(),
+    this.oa = const Value.absent(),
+    this.ash = const Value.absent(),
+    this.na = const Value.absent(),
+    this.k = const Value.absent(),
+    this.ca = const Value.absent(),
+    this.mg = const Value.absent(),
+    this.p = const Value.absent(),
+    this.fe = const Value.absent(),
+    this.zn = const Value.absent(),
+    this.cu = const Value.absent(),
+    this.mn = const Value.absent(),
+    this.iodine = const Value.absent(),
+    this.se = const Value.absent(),
+    this.cr = const Value.absent(),
+    this.mo = const Value.absent(),
+    this.retol = const Value.absent(),
+    this.carta = const Value.absent(),
+    this.cartb = const Value.absent(),
+    this.crypxb = const Value.absent(),
+    this.cartbeq = const Value.absent(),
+    this.vitaRae = const Value.absent(),
+    this.vitD = const Value.absent(),
+    this.tocphA = const Value.absent(),
+    this.tocphB = const Value.absent(),
+    this.tocphG = const Value.absent(),
+    this.tocphD = const Value.absent(),
+    this.vitK = const Value.absent(),
+    this.thia = const Value.absent(),
+    this.ribf = const Value.absent(),
+    this.nia = const Value.absent(),
+    this.ne = const Value.absent(),
+    this.vitB6A = const Value.absent(),
+    this.vitB12 = const Value.absent(),
+    this.fol = const Value.absent(),
+    this.pantac = const Value.absent(),
+    this.biot = const Value.absent(),
+    this.vitC = const Value.absent(),
+    this.alc = const Value.absent(),
+    this.naclEq = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  });
+  JapaneseFoodCompositionTableCompanion.insert({
+    this.id = const Value.absent(),
+    required int groupId,
+    required int foodId,
+    required int indexId,
+    required String foodName,
+    this.refuse = const Value.absent(),
+    this.enerc = const Value.absent(),
+    this.enercKcal = const Value.absent(),
+    this.water = const Value.absent(),
+    this.protcaa = const Value.absent(),
+    this.prot = const Value.absent(),
+    this.fatnlea = const Value.absent(),
+    this.chole = const Value.absent(),
+    this.fat = const Value.absent(),
+    this.choavlm = const Value.absent(),
+    this.choavl = const Value.absent(),
+    this.choavldf = const Value.absent(),
+    this.fib = const Value.absent(),
+    this.polyl = const Value.absent(),
+    this.chocdf = const Value.absent(),
+    this.oa = const Value.absent(),
+    this.ash = const Value.absent(),
+    this.na = const Value.absent(),
+    this.k = const Value.absent(),
+    this.ca = const Value.absent(),
+    this.mg = const Value.absent(),
+    this.p = const Value.absent(),
+    this.fe = const Value.absent(),
+    this.zn = const Value.absent(),
+    this.cu = const Value.absent(),
+    this.mn = const Value.absent(),
+    this.iodine = const Value.absent(),
+    this.se = const Value.absent(),
+    this.cr = const Value.absent(),
+    this.mo = const Value.absent(),
+    this.retol = const Value.absent(),
+    this.carta = const Value.absent(),
+    this.cartb = const Value.absent(),
+    this.crypxb = const Value.absent(),
+    this.cartbeq = const Value.absent(),
+    this.vitaRae = const Value.absent(),
+    this.vitD = const Value.absent(),
+    this.tocphA = const Value.absent(),
+    this.tocphB = const Value.absent(),
+    this.tocphG = const Value.absent(),
+    this.tocphD = const Value.absent(),
+    this.vitK = const Value.absent(),
+    this.thia = const Value.absent(),
+    this.ribf = const Value.absent(),
+    this.nia = const Value.absent(),
+    this.ne = const Value.absent(),
+    this.vitB6A = const Value.absent(),
+    this.vitB12 = const Value.absent(),
+    this.fol = const Value.absent(),
+    this.pantac = const Value.absent(),
+    this.biot = const Value.absent(),
+    this.vitC = const Value.absent(),
+    this.alc = const Value.absent(),
+    this.naclEq = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  })  : groupId = Value(groupId),
+        foodId = Value(foodId),
+        indexId = Value(indexId),
+        foodName = Value(foodName);
+  static Insertable<JapaneseFoodCompositionTableData> custom({
+    Expression<int>? id,
+    Expression<int>? groupId,
+    Expression<int>? foodId,
+    Expression<int>? indexId,
+    Expression<String>? foodName,
+    Expression<double>? refuse,
+    Expression<double>? enerc,
+    Expression<double>? enercKcal,
+    Expression<double>? water,
+    Expression<double>? protcaa,
+    Expression<double>? prot,
+    Expression<double>? fatnlea,
+    Expression<double>? chole,
+    Expression<double>? fat,
+    Expression<double>? choavlm,
+    Expression<double>? choavl,
+    Expression<double>? choavldf,
+    Expression<double>? fib,
+    Expression<double>? polyl,
+    Expression<double>? chocdf,
+    Expression<double>? oa,
+    Expression<double>? ash,
+    Expression<double>? na,
+    Expression<double>? k,
+    Expression<double>? ca,
+    Expression<double>? mg,
+    Expression<double>? p,
+    Expression<double>? fe,
+    Expression<double>? zn,
+    Expression<double>? cu,
+    Expression<double>? mn,
+    Expression<double>? iodine,
+    Expression<double>? se,
+    Expression<double>? cr,
+    Expression<double>? mo,
+    Expression<double>? retol,
+    Expression<double>? carta,
+    Expression<double>? cartb,
+    Expression<double>? crypxb,
+    Expression<double>? cartbeq,
+    Expression<double>? vitaRae,
+    Expression<double>? vitD,
+    Expression<double>? tocphA,
+    Expression<double>? tocphB,
+    Expression<double>? tocphG,
+    Expression<double>? tocphD,
+    Expression<double>? vitK,
+    Expression<double>? thia,
+    Expression<double>? ribf,
+    Expression<double>? nia,
+    Expression<double>? ne,
+    Expression<double>? vitB6A,
+    Expression<double>? vitB12,
+    Expression<double>? fol,
+    Expression<double>? pantac,
+    Expression<double>? biot,
+    Expression<double>? vitC,
+    Expression<double>? alc,
+    Expression<double>? naclEq,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (groupId != null) 'group_id': groupId,
+      if (foodId != null) 'food_id': foodId,
+      if (indexId != null) 'index_id': indexId,
+      if (foodName != null) 'food_name': foodName,
+      if (refuse != null) 'refuse': refuse,
+      if (enerc != null) 'enerc': enerc,
+      if (enercKcal != null) 'enerc_kcal': enercKcal,
+      if (water != null) 'water': water,
+      if (protcaa != null) 'protcaa': protcaa,
+      if (prot != null) 'prot': prot,
+      if (fatnlea != null) 'fatnlea': fatnlea,
+      if (chole != null) 'chole': chole,
+      if (fat != null) 'fat': fat,
+      if (choavlm != null) 'choavlm': choavlm,
+      if (choavl != null) 'choavl': choavl,
+      if (choavldf != null) 'choavldf': choavldf,
+      if (fib != null) 'fib': fib,
+      if (polyl != null) 'polyl': polyl,
+      if (chocdf != null) 'chocdf': chocdf,
+      if (oa != null) 'oa': oa,
+      if (ash != null) 'ash': ash,
+      if (na != null) 'na': na,
+      if (k != null) 'k': k,
+      if (ca != null) 'ca': ca,
+      if (mg != null) 'mg': mg,
+      if (p != null) 'p': p,
+      if (fe != null) 'fe': fe,
+      if (zn != null) 'zn': zn,
+      if (cu != null) 'cu': cu,
+      if (mn != null) 'mn': mn,
+      if (iodine != null) 'iodine': iodine,
+      if (se != null) 'se': se,
+      if (cr != null) 'cr': cr,
+      if (mo != null) 'mo': mo,
+      if (retol != null) 'retol': retol,
+      if (carta != null) 'carta': carta,
+      if (cartb != null) 'cartb': cartb,
+      if (crypxb != null) 'crypxb': crypxb,
+      if (cartbeq != null) 'cartbeq': cartbeq,
+      if (vitaRae != null) 'vita_rae': vitaRae,
+      if (vitD != null) 'vit_d': vitD,
+      if (tocphA != null) 'tocph_a': tocphA,
+      if (tocphB != null) 'tocph_b': tocphB,
+      if (tocphG != null) 'tocph_g': tocphG,
+      if (tocphD != null) 'tocph_d': tocphD,
+      if (vitK != null) 'vit_k': vitK,
+      if (thia != null) 'thia': thia,
+      if (ribf != null) 'ribf': ribf,
+      if (nia != null) 'nia': nia,
+      if (ne != null) 'ne': ne,
+      if (vitB6A != null) 'vit_b6_a': vitB6A,
+      if (vitB12 != null) 'vit_b12': vitB12,
+      if (fol != null) 'fol': fol,
+      if (pantac != null) 'pantac': pantac,
+      if (biot != null) 'biot': biot,
+      if (vitC != null) 'vit_c': vitC,
+      if (alc != null) 'alc': alc,
+      if (naclEq != null) 'nacl_eq': naclEq,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+    });
+  }
+
+  JapaneseFoodCompositionTableCompanion copyWith(
+      {Value<int>? id,
+      Value<int>? groupId,
+      Value<int>? foodId,
+      Value<int>? indexId,
+      Value<String>? foodName,
+      Value<double>? refuse,
+      Value<double?>? enerc,
+      Value<double?>? enercKcal,
+      Value<double?>? water,
+      Value<double?>? protcaa,
+      Value<double?>? prot,
+      Value<double?>? fatnlea,
+      Value<double?>? chole,
+      Value<double?>? fat,
+      Value<double?>? choavlm,
+      Value<double?>? choavl,
+      Value<double?>? choavldf,
+      Value<double?>? fib,
+      Value<double?>? polyl,
+      Value<double?>? chocdf,
+      Value<double?>? oa,
+      Value<double?>? ash,
+      Value<double?>? na,
+      Value<double?>? k,
+      Value<double?>? ca,
+      Value<double?>? mg,
+      Value<double?>? p,
+      Value<double?>? fe,
+      Value<double?>? zn,
+      Value<double?>? cu,
+      Value<double?>? mn,
+      Value<double?>? iodine,
+      Value<double?>? se,
+      Value<double?>? cr,
+      Value<double?>? mo,
+      Value<double?>? retol,
+      Value<double?>? carta,
+      Value<double?>? cartb,
+      Value<double?>? crypxb,
+      Value<double?>? cartbeq,
+      Value<double?>? vitaRae,
+      Value<double?>? vitD,
+      Value<double?>? tocphA,
+      Value<double?>? tocphB,
+      Value<double?>? tocphG,
+      Value<double?>? tocphD,
+      Value<double?>? vitK,
+      Value<double?>? thia,
+      Value<double?>? ribf,
+      Value<double?>? nia,
+      Value<double?>? ne,
+      Value<double?>? vitB6A,
+      Value<double?>? vitB12,
+      Value<double?>? fol,
+      Value<double?>? pantac,
+      Value<double?>? biot,
+      Value<double?>? vitC,
+      Value<double?>? alc,
+      Value<double?>? naclEq,
+      Value<DateTime>? createdAt,
+      Value<DateTime>? updatedAt}) {
+    return JapaneseFoodCompositionTableCompanion(
+      id: id ?? this.id,
+      groupId: groupId ?? this.groupId,
+      foodId: foodId ?? this.foodId,
+      indexId: indexId ?? this.indexId,
+      foodName: foodName ?? this.foodName,
+      refuse: refuse ?? this.refuse,
+      enerc: enerc ?? this.enerc,
+      enercKcal: enercKcal ?? this.enercKcal,
+      water: water ?? this.water,
+      protcaa: protcaa ?? this.protcaa,
+      prot: prot ?? this.prot,
+      fatnlea: fatnlea ?? this.fatnlea,
+      chole: chole ?? this.chole,
+      fat: fat ?? this.fat,
+      choavlm: choavlm ?? this.choavlm,
+      choavl: choavl ?? this.choavl,
+      choavldf: choavldf ?? this.choavldf,
+      fib: fib ?? this.fib,
+      polyl: polyl ?? this.polyl,
+      chocdf: chocdf ?? this.chocdf,
+      oa: oa ?? this.oa,
+      ash: ash ?? this.ash,
+      na: na ?? this.na,
+      k: k ?? this.k,
+      ca: ca ?? this.ca,
+      mg: mg ?? this.mg,
+      p: p ?? this.p,
+      fe: fe ?? this.fe,
+      zn: zn ?? this.zn,
+      cu: cu ?? this.cu,
+      mn: mn ?? this.mn,
+      iodine: iodine ?? this.iodine,
+      se: se ?? this.se,
+      cr: cr ?? this.cr,
+      mo: mo ?? this.mo,
+      retol: retol ?? this.retol,
+      carta: carta ?? this.carta,
+      cartb: cartb ?? this.cartb,
+      crypxb: crypxb ?? this.crypxb,
+      cartbeq: cartbeq ?? this.cartbeq,
+      vitaRae: vitaRae ?? this.vitaRae,
+      vitD: vitD ?? this.vitD,
+      tocphA: tocphA ?? this.tocphA,
+      tocphB: tocphB ?? this.tocphB,
+      tocphG: tocphG ?? this.tocphG,
+      tocphD: tocphD ?? this.tocphD,
+      vitK: vitK ?? this.vitK,
+      thia: thia ?? this.thia,
+      ribf: ribf ?? this.ribf,
+      nia: nia ?? this.nia,
+      ne: ne ?? this.ne,
+      vitB6A: vitB6A ?? this.vitB6A,
+      vitB12: vitB12 ?? this.vitB12,
+      fol: fol ?? this.fol,
+      pantac: pantac ?? this.pantac,
+      biot: biot ?? this.biot,
+      vitC: vitC ?? this.vitC,
+      alc: alc ?? this.alc,
+      naclEq: naclEq ?? this.naclEq,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (groupId.present) {
+      map['group_id'] = Variable<int>(groupId.value);
+    }
+    if (foodId.present) {
+      map['food_id'] = Variable<int>(foodId.value);
+    }
+    if (indexId.present) {
+      map['index_id'] = Variable<int>(indexId.value);
+    }
+    if (foodName.present) {
+      map['food_name'] = Variable<String>(foodName.value);
+    }
+    if (refuse.present) {
+      map['refuse'] = Variable<double>(refuse.value);
+    }
+    if (enerc.present) {
+      map['enerc'] = Variable<double>(enerc.value);
+    }
+    if (enercKcal.present) {
+      map['enerc_kcal'] = Variable<double>(enercKcal.value);
+    }
+    if (water.present) {
+      map['water'] = Variable<double>(water.value);
+    }
+    if (protcaa.present) {
+      map['protcaa'] = Variable<double>(protcaa.value);
+    }
+    if (prot.present) {
+      map['prot'] = Variable<double>(prot.value);
+    }
+    if (fatnlea.present) {
+      map['fatnlea'] = Variable<double>(fatnlea.value);
+    }
+    if (chole.present) {
+      map['chole'] = Variable<double>(chole.value);
+    }
+    if (fat.present) {
+      map['fat'] = Variable<double>(fat.value);
+    }
+    if (choavlm.present) {
+      map['choavlm'] = Variable<double>(choavlm.value);
+    }
+    if (choavl.present) {
+      map['choavl'] = Variable<double>(choavl.value);
+    }
+    if (choavldf.present) {
+      map['choavldf'] = Variable<double>(choavldf.value);
+    }
+    if (fib.present) {
+      map['fib'] = Variable<double>(fib.value);
+    }
+    if (polyl.present) {
+      map['polyl'] = Variable<double>(polyl.value);
+    }
+    if (chocdf.present) {
+      map['chocdf'] = Variable<double>(chocdf.value);
+    }
+    if (oa.present) {
+      map['oa'] = Variable<double>(oa.value);
+    }
+    if (ash.present) {
+      map['ash'] = Variable<double>(ash.value);
+    }
+    if (na.present) {
+      map['na'] = Variable<double>(na.value);
+    }
+    if (k.present) {
+      map['k'] = Variable<double>(k.value);
+    }
+    if (ca.present) {
+      map['ca'] = Variable<double>(ca.value);
+    }
+    if (mg.present) {
+      map['mg'] = Variable<double>(mg.value);
+    }
+    if (p.present) {
+      map['p'] = Variable<double>(p.value);
+    }
+    if (fe.present) {
+      map['fe'] = Variable<double>(fe.value);
+    }
+    if (zn.present) {
+      map['zn'] = Variable<double>(zn.value);
+    }
+    if (cu.present) {
+      map['cu'] = Variable<double>(cu.value);
+    }
+    if (mn.present) {
+      map['mn'] = Variable<double>(mn.value);
+    }
+    if (iodine.present) {
+      map['iodine'] = Variable<double>(iodine.value);
+    }
+    if (se.present) {
+      map['se'] = Variable<double>(se.value);
+    }
+    if (cr.present) {
+      map['cr'] = Variable<double>(cr.value);
+    }
+    if (mo.present) {
+      map['mo'] = Variable<double>(mo.value);
+    }
+    if (retol.present) {
+      map['retol'] = Variable<double>(retol.value);
+    }
+    if (carta.present) {
+      map['carta'] = Variable<double>(carta.value);
+    }
+    if (cartb.present) {
+      map['cartb'] = Variable<double>(cartb.value);
+    }
+    if (crypxb.present) {
+      map['crypxb'] = Variable<double>(crypxb.value);
+    }
+    if (cartbeq.present) {
+      map['cartbeq'] = Variable<double>(cartbeq.value);
+    }
+    if (vitaRae.present) {
+      map['vita_rae'] = Variable<double>(vitaRae.value);
+    }
+    if (vitD.present) {
+      map['vit_d'] = Variable<double>(vitD.value);
+    }
+    if (tocphA.present) {
+      map['tocph_a'] = Variable<double>(tocphA.value);
+    }
+    if (tocphB.present) {
+      map['tocph_b'] = Variable<double>(tocphB.value);
+    }
+    if (tocphG.present) {
+      map['tocph_g'] = Variable<double>(tocphG.value);
+    }
+    if (tocphD.present) {
+      map['tocph_d'] = Variable<double>(tocphD.value);
+    }
+    if (vitK.present) {
+      map['vit_k'] = Variable<double>(vitK.value);
+    }
+    if (thia.present) {
+      map['thia'] = Variable<double>(thia.value);
+    }
+    if (ribf.present) {
+      map['ribf'] = Variable<double>(ribf.value);
+    }
+    if (nia.present) {
+      map['nia'] = Variable<double>(nia.value);
+    }
+    if (ne.present) {
+      map['ne'] = Variable<double>(ne.value);
+    }
+    if (vitB6A.present) {
+      map['vit_b6_a'] = Variable<double>(vitB6A.value);
+    }
+    if (vitB12.present) {
+      map['vit_b12'] = Variable<double>(vitB12.value);
+    }
+    if (fol.present) {
+      map['fol'] = Variable<double>(fol.value);
+    }
+    if (pantac.present) {
+      map['pantac'] = Variable<double>(pantac.value);
+    }
+    if (biot.present) {
+      map['biot'] = Variable<double>(biot.value);
+    }
+    if (vitC.present) {
+      map['vit_c'] = Variable<double>(vitC.value);
+    }
+    if (alc.present) {
+      map['alc'] = Variable<double>(alc.value);
+    }
+    if (naclEq.present) {
+      map['nacl_eq'] = Variable<double>(naclEq.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('JapaneseFoodCompositionTableCompanion(')
+          ..write('id: $id, ')
+          ..write('groupId: $groupId, ')
+          ..write('foodId: $foodId, ')
+          ..write('indexId: $indexId, ')
+          ..write('foodName: $foodName, ')
+          ..write('refuse: $refuse, ')
+          ..write('enerc: $enerc, ')
+          ..write('enercKcal: $enercKcal, ')
+          ..write('water: $water, ')
+          ..write('protcaa: $protcaa, ')
+          ..write('prot: $prot, ')
+          ..write('fatnlea: $fatnlea, ')
+          ..write('chole: $chole, ')
+          ..write('fat: $fat, ')
+          ..write('choavlm: $choavlm, ')
+          ..write('choavl: $choavl, ')
+          ..write('choavldf: $choavldf, ')
+          ..write('fib: $fib, ')
+          ..write('polyl: $polyl, ')
+          ..write('chocdf: $chocdf, ')
+          ..write('oa: $oa, ')
+          ..write('ash: $ash, ')
+          ..write('na: $na, ')
+          ..write('k: $k, ')
+          ..write('ca: $ca, ')
+          ..write('mg: $mg, ')
+          ..write('p: $p, ')
+          ..write('fe: $fe, ')
+          ..write('zn: $zn, ')
+          ..write('cu: $cu, ')
+          ..write('mn: $mn, ')
+          ..write('iodine: $iodine, ')
+          ..write('se: $se, ')
+          ..write('cr: $cr, ')
+          ..write('mo: $mo, ')
+          ..write('retol: $retol, ')
+          ..write('carta: $carta, ')
+          ..write('cartb: $cartb, ')
+          ..write('crypxb: $crypxb, ')
+          ..write('cartbeq: $cartbeq, ')
+          ..write('vitaRae: $vitaRae, ')
+          ..write('vitD: $vitD, ')
+          ..write('tocphA: $tocphA, ')
+          ..write('tocphB: $tocphB, ')
+          ..write('tocphG: $tocphG, ')
+          ..write('tocphD: $tocphD, ')
+          ..write('vitK: $vitK, ')
+          ..write('thia: $thia, ')
+          ..write('ribf: $ribf, ')
+          ..write('nia: $nia, ')
+          ..write('ne: $ne, ')
+          ..write('vitB6A: $vitB6A, ')
+          ..write('vitB12: $vitB12, ')
+          ..write('fol: $fol, ')
+          ..write('pantac: $pantac, ')
+          ..write('biot: $biot, ')
+          ..write('vitC: $vitC, ')
+          ..write('alc: $alc, ')
+          ..write('naclEq: $naclEq, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -3727,6 +5719,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $PersonalDataTableTable(this);
   late final $FoodItemTableTable foodItemTable = $FoodItemTableTable(this);
   late final $RecipeTableTable recipeTable = $RecipeTableTable(this);
+  late final $JapaneseFoodCompositionTableTable japaneseFoodCompositionTable =
+      $JapaneseFoodCompositionTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -3737,7 +5731,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         mealItemTable,
         personalDataTable,
         foodItemTable,
-        recipeTable
+        recipeTable,
+        japaneseFoodCompositionTable
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(
@@ -4097,6 +6092,17 @@ typedef $$ExternalRecipeTableTableCreateCompanionBuilder
   Value<bool> isFavorite,
   Value<String?> tags,
   Value<String?> memo,
+  Value<String?> ingredientsJson,
+  Value<String?> ingredientsRawText,
+  Value<double?> calories,
+  Value<double?> protein,
+  Value<double?> fat,
+  Value<double?> carbohydrate,
+  Value<double?> salt,
+  Value<double?> fiber,
+  Value<double?> vitaminC,
+  Value<bool> isNutritionAutoExtracted,
+  Value<int> servings,
   Value<DateTime?> lastAccessedAt,
   Value<DateTime> createdAt,
   Value<DateTime> updatedAt,
@@ -4112,6 +6118,17 @@ typedef $$ExternalRecipeTableTableUpdateCompanionBuilder
   Value<bool> isFavorite,
   Value<String?> tags,
   Value<String?> memo,
+  Value<String?> ingredientsJson,
+  Value<String?> ingredientsRawText,
+  Value<double?> calories,
+  Value<double?> protein,
+  Value<double?> fat,
+  Value<double?> carbohydrate,
+  Value<double?> salt,
+  Value<double?> fiber,
+  Value<double?> vitaminC,
+  Value<bool> isNutritionAutoExtracted,
+  Value<int> servings,
   Value<DateTime?> lastAccessedAt,
   Value<DateTime> createdAt,
   Value<DateTime> updatedAt,
@@ -4174,6 +6191,42 @@ class $$ExternalRecipeTableTableFilterComposer
 
   ColumnFilters<String> get memo => $composableBuilder(
       column: $table.memo, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get ingredientsJson => $composableBuilder(
+      column: $table.ingredientsJson,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get ingredientsRawText => $composableBuilder(
+      column: $table.ingredientsRawText,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get calories => $composableBuilder(
+      column: $table.calories, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get protein => $composableBuilder(
+      column: $table.protein, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fat => $composableBuilder(
+      column: $table.fat, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get carbohydrate => $composableBuilder(
+      column: $table.carbohydrate, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get salt => $composableBuilder(
+      column: $table.salt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fiber => $composableBuilder(
+      column: $table.fiber, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitaminC => $composableBuilder(
+      column: $table.vitaminC, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get isNutritionAutoExtracted => $composableBuilder(
+      column: $table.isNutritionAutoExtracted,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get servings => $composableBuilder(
+      column: $table.servings, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get lastAccessedAt => $composableBuilder(
       column: $table.lastAccessedAt,
@@ -4243,6 +6296,43 @@ class $$ExternalRecipeTableTableOrderingComposer
   ColumnOrderings<String> get memo => $composableBuilder(
       column: $table.memo, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get ingredientsJson => $composableBuilder(
+      column: $table.ingredientsJson,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get ingredientsRawText => $composableBuilder(
+      column: $table.ingredientsRawText,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get calories => $composableBuilder(
+      column: $table.calories, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get protein => $composableBuilder(
+      column: $table.protein, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fat => $composableBuilder(
+      column: $table.fat, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get carbohydrate => $composableBuilder(
+      column: $table.carbohydrate,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get salt => $composableBuilder(
+      column: $table.salt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fiber => $composableBuilder(
+      column: $table.fiber, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitaminC => $composableBuilder(
+      column: $table.vitaminC, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get isNutritionAutoExtracted => $composableBuilder(
+      column: $table.isNutritionAutoExtracted,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get servings => $composableBuilder(
+      column: $table.servings, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get lastAccessedAt => $composableBuilder(
       column: $table.lastAccessedAt,
       builder: (column) => ColumnOrderings(column));
@@ -4289,6 +6379,39 @@ class $$ExternalRecipeTableTableAnnotationComposer
 
   GeneratedColumn<String> get memo =>
       $composableBuilder(column: $table.memo, builder: (column) => column);
+
+  GeneratedColumn<String> get ingredientsJson => $composableBuilder(
+      column: $table.ingredientsJson, builder: (column) => column);
+
+  GeneratedColumn<String> get ingredientsRawText => $composableBuilder(
+      column: $table.ingredientsRawText, builder: (column) => column);
+
+  GeneratedColumn<double> get calories =>
+      $composableBuilder(column: $table.calories, builder: (column) => column);
+
+  GeneratedColumn<double> get protein =>
+      $composableBuilder(column: $table.protein, builder: (column) => column);
+
+  GeneratedColumn<double> get fat =>
+      $composableBuilder(column: $table.fat, builder: (column) => column);
+
+  GeneratedColumn<double> get carbohydrate => $composableBuilder(
+      column: $table.carbohydrate, builder: (column) => column);
+
+  GeneratedColumn<double> get salt =>
+      $composableBuilder(column: $table.salt, builder: (column) => column);
+
+  GeneratedColumn<double> get fiber =>
+      $composableBuilder(column: $table.fiber, builder: (column) => column);
+
+  GeneratedColumn<double> get vitaminC =>
+      $composableBuilder(column: $table.vitaminC, builder: (column) => column);
+
+  GeneratedColumn<bool> get isNutritionAutoExtracted => $composableBuilder(
+      column: $table.isNutritionAutoExtracted, builder: (column) => column);
+
+  GeneratedColumn<int> get servings =>
+      $composableBuilder(column: $table.servings, builder: (column) => column);
 
   GeneratedColumn<DateTime> get lastAccessedAt => $composableBuilder(
       column: $table.lastAccessedAt, builder: (column) => column);
@@ -4356,6 +6479,17 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             Value<bool> isFavorite = const Value.absent(),
             Value<String?> tags = const Value.absent(),
             Value<String?> memo = const Value.absent(),
+            Value<String?> ingredientsJson = const Value.absent(),
+            Value<String?> ingredientsRawText = const Value.absent(),
+            Value<double?> calories = const Value.absent(),
+            Value<double?> protein = const Value.absent(),
+            Value<double?> fat = const Value.absent(),
+            Value<double?> carbohydrate = const Value.absent(),
+            Value<double?> salt = const Value.absent(),
+            Value<double?> fiber = const Value.absent(),
+            Value<double?> vitaminC = const Value.absent(),
+            Value<bool> isNutritionAutoExtracted = const Value.absent(),
+            Value<int> servings = const Value.absent(),
             Value<DateTime?> lastAccessedAt = const Value.absent(),
             Value<DateTime> createdAt = const Value.absent(),
             Value<DateTime> updatedAt = const Value.absent(),
@@ -4370,6 +6504,17 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             isFavorite: isFavorite,
             tags: tags,
             memo: memo,
+            ingredientsJson: ingredientsJson,
+            ingredientsRawText: ingredientsRawText,
+            calories: calories,
+            protein: protein,
+            fat: fat,
+            carbohydrate: carbohydrate,
+            salt: salt,
+            fiber: fiber,
+            vitaminC: vitaminC,
+            isNutritionAutoExtracted: isNutritionAutoExtracted,
+            servings: servings,
             lastAccessedAt: lastAccessedAt,
             createdAt: createdAt,
             updatedAt: updatedAt,
@@ -4384,6 +6529,17 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             Value<bool> isFavorite = const Value.absent(),
             Value<String?> tags = const Value.absent(),
             Value<String?> memo = const Value.absent(),
+            Value<String?> ingredientsJson = const Value.absent(),
+            Value<String?> ingredientsRawText = const Value.absent(),
+            Value<double?> calories = const Value.absent(),
+            Value<double?> protein = const Value.absent(),
+            Value<double?> fat = const Value.absent(),
+            Value<double?> carbohydrate = const Value.absent(),
+            Value<double?> salt = const Value.absent(),
+            Value<double?> fiber = const Value.absent(),
+            Value<double?> vitaminC = const Value.absent(),
+            Value<bool> isNutritionAutoExtracted = const Value.absent(),
+            Value<int> servings = const Value.absent(),
             Value<DateTime?> lastAccessedAt = const Value.absent(),
             Value<DateTime> createdAt = const Value.absent(),
             Value<DateTime> updatedAt = const Value.absent(),
@@ -4398,6 +6554,17 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             isFavorite: isFavorite,
             tags: tags,
             memo: memo,
+            ingredientsJson: ingredientsJson,
+            ingredientsRawText: ingredientsRawText,
+            calories: calories,
+            protein: protein,
+            fat: fat,
+            carbohydrate: carbohydrate,
+            salt: salt,
+            fiber: fiber,
+            vitaminC: vitaminC,
+            isNutritionAutoExtracted: isNutritionAutoExtracted,
+            servings: servings,
             lastAccessedAt: lastAccessedAt,
             createdAt: createdAt,
             updatedAt: updatedAt,
@@ -5770,6 +7937,1020 @@ typedef $$RecipeTableTableProcessedTableManager = ProcessedTableManager<
     ),
     RecipeTableData,
     PrefetchHooks Function()>;
+typedef $$JapaneseFoodCompositionTableTableCreateCompanionBuilder
+    = JapaneseFoodCompositionTableCompanion Function({
+  Value<int> id,
+  required int groupId,
+  required int foodId,
+  required int indexId,
+  required String foodName,
+  Value<double> refuse,
+  Value<double?> enerc,
+  Value<double?> enercKcal,
+  Value<double?> water,
+  Value<double?> protcaa,
+  Value<double?> prot,
+  Value<double?> fatnlea,
+  Value<double?> chole,
+  Value<double?> fat,
+  Value<double?> choavlm,
+  Value<double?> choavl,
+  Value<double?> choavldf,
+  Value<double?> fib,
+  Value<double?> polyl,
+  Value<double?> chocdf,
+  Value<double?> oa,
+  Value<double?> ash,
+  Value<double?> na,
+  Value<double?> k,
+  Value<double?> ca,
+  Value<double?> mg,
+  Value<double?> p,
+  Value<double?> fe,
+  Value<double?> zn,
+  Value<double?> cu,
+  Value<double?> mn,
+  Value<double?> iodine,
+  Value<double?> se,
+  Value<double?> cr,
+  Value<double?> mo,
+  Value<double?> retol,
+  Value<double?> carta,
+  Value<double?> cartb,
+  Value<double?> crypxb,
+  Value<double?> cartbeq,
+  Value<double?> vitaRae,
+  Value<double?> vitD,
+  Value<double?> tocphA,
+  Value<double?> tocphB,
+  Value<double?> tocphG,
+  Value<double?> tocphD,
+  Value<double?> vitK,
+  Value<double?> thia,
+  Value<double?> ribf,
+  Value<double?> nia,
+  Value<double?> ne,
+  Value<double?> vitB6A,
+  Value<double?> vitB12,
+  Value<double?> fol,
+  Value<double?> pantac,
+  Value<double?> biot,
+  Value<double?> vitC,
+  Value<double?> alc,
+  Value<double?> naclEq,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+typedef $$JapaneseFoodCompositionTableTableUpdateCompanionBuilder
+    = JapaneseFoodCompositionTableCompanion Function({
+  Value<int> id,
+  Value<int> groupId,
+  Value<int> foodId,
+  Value<int> indexId,
+  Value<String> foodName,
+  Value<double> refuse,
+  Value<double?> enerc,
+  Value<double?> enercKcal,
+  Value<double?> water,
+  Value<double?> protcaa,
+  Value<double?> prot,
+  Value<double?> fatnlea,
+  Value<double?> chole,
+  Value<double?> fat,
+  Value<double?> choavlm,
+  Value<double?> choavl,
+  Value<double?> choavldf,
+  Value<double?> fib,
+  Value<double?> polyl,
+  Value<double?> chocdf,
+  Value<double?> oa,
+  Value<double?> ash,
+  Value<double?> na,
+  Value<double?> k,
+  Value<double?> ca,
+  Value<double?> mg,
+  Value<double?> p,
+  Value<double?> fe,
+  Value<double?> zn,
+  Value<double?> cu,
+  Value<double?> mn,
+  Value<double?> iodine,
+  Value<double?> se,
+  Value<double?> cr,
+  Value<double?> mo,
+  Value<double?> retol,
+  Value<double?> carta,
+  Value<double?> cartb,
+  Value<double?> crypxb,
+  Value<double?> cartbeq,
+  Value<double?> vitaRae,
+  Value<double?> vitD,
+  Value<double?> tocphA,
+  Value<double?> tocphB,
+  Value<double?> tocphG,
+  Value<double?> tocphD,
+  Value<double?> vitK,
+  Value<double?> thia,
+  Value<double?> ribf,
+  Value<double?> nia,
+  Value<double?> ne,
+  Value<double?> vitB6A,
+  Value<double?> vitB12,
+  Value<double?> fol,
+  Value<double?> pantac,
+  Value<double?> biot,
+  Value<double?> vitC,
+  Value<double?> alc,
+  Value<double?> naclEq,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+
+class $$JapaneseFoodCompositionTableTableFilterComposer
+    extends Composer<_$AppDatabase, $JapaneseFoodCompositionTableTable> {
+  $$JapaneseFoodCompositionTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get groupId => $composableBuilder(
+      column: $table.groupId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get foodId => $composableBuilder(
+      column: $table.foodId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get indexId => $composableBuilder(
+      column: $table.indexId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get foodName => $composableBuilder(
+      column: $table.foodName, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get refuse => $composableBuilder(
+      column: $table.refuse, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get enerc => $composableBuilder(
+      column: $table.enerc, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get enercKcal => $composableBuilder(
+      column: $table.enercKcal, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get water => $composableBuilder(
+      column: $table.water, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get protcaa => $composableBuilder(
+      column: $table.protcaa, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get prot => $composableBuilder(
+      column: $table.prot, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fatnlea => $composableBuilder(
+      column: $table.fatnlea, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get chole => $composableBuilder(
+      column: $table.chole, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fat => $composableBuilder(
+      column: $table.fat, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get choavlm => $composableBuilder(
+      column: $table.choavlm, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get choavl => $composableBuilder(
+      column: $table.choavl, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get choavldf => $composableBuilder(
+      column: $table.choavldf, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fib => $composableBuilder(
+      column: $table.fib, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get polyl => $composableBuilder(
+      column: $table.polyl, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get chocdf => $composableBuilder(
+      column: $table.chocdf, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get oa => $composableBuilder(
+      column: $table.oa, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get ash => $composableBuilder(
+      column: $table.ash, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get na => $composableBuilder(
+      column: $table.na, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get k => $composableBuilder(
+      column: $table.k, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get ca => $composableBuilder(
+      column: $table.ca, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get mg => $composableBuilder(
+      column: $table.mg, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get p => $composableBuilder(
+      column: $table.p, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fe => $composableBuilder(
+      column: $table.fe, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get zn => $composableBuilder(
+      column: $table.zn, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get cu => $composableBuilder(
+      column: $table.cu, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get mn => $composableBuilder(
+      column: $table.mn, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get iodine => $composableBuilder(
+      column: $table.iodine, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get se => $composableBuilder(
+      column: $table.se, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get cr => $composableBuilder(
+      column: $table.cr, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get mo => $composableBuilder(
+      column: $table.mo, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get retol => $composableBuilder(
+      column: $table.retol, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get carta => $composableBuilder(
+      column: $table.carta, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get cartb => $composableBuilder(
+      column: $table.cartb, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get crypxb => $composableBuilder(
+      column: $table.crypxb, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get cartbeq => $composableBuilder(
+      column: $table.cartbeq, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitaRae => $composableBuilder(
+      column: $table.vitaRae, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitD => $composableBuilder(
+      column: $table.vitD, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get tocphA => $composableBuilder(
+      column: $table.tocphA, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get tocphB => $composableBuilder(
+      column: $table.tocphB, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get tocphG => $composableBuilder(
+      column: $table.tocphG, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get tocphD => $composableBuilder(
+      column: $table.tocphD, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitK => $composableBuilder(
+      column: $table.vitK, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get thia => $composableBuilder(
+      column: $table.thia, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get ribf => $composableBuilder(
+      column: $table.ribf, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get nia => $composableBuilder(
+      column: $table.nia, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get ne => $composableBuilder(
+      column: $table.ne, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitB6A => $composableBuilder(
+      column: $table.vitB6A, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitB12 => $composableBuilder(
+      column: $table.vitB12, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get fol => $composableBuilder(
+      column: $table.fol, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get pantac => $composableBuilder(
+      column: $table.pantac, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get biot => $composableBuilder(
+      column: $table.biot, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get vitC => $composableBuilder(
+      column: $table.vitC, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get alc => $composableBuilder(
+      column: $table.alc, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get naclEq => $composableBuilder(
+      column: $table.naclEq, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$JapaneseFoodCompositionTableTableOrderingComposer
+    extends Composer<_$AppDatabase, $JapaneseFoodCompositionTableTable> {
+  $$JapaneseFoodCompositionTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get groupId => $composableBuilder(
+      column: $table.groupId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get foodId => $composableBuilder(
+      column: $table.foodId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get indexId => $composableBuilder(
+      column: $table.indexId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get foodName => $composableBuilder(
+      column: $table.foodName, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get refuse => $composableBuilder(
+      column: $table.refuse, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get enerc => $composableBuilder(
+      column: $table.enerc, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get enercKcal => $composableBuilder(
+      column: $table.enercKcal, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get water => $composableBuilder(
+      column: $table.water, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get protcaa => $composableBuilder(
+      column: $table.protcaa, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get prot => $composableBuilder(
+      column: $table.prot, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fatnlea => $composableBuilder(
+      column: $table.fatnlea, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get chole => $composableBuilder(
+      column: $table.chole, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fat => $composableBuilder(
+      column: $table.fat, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get choavlm => $composableBuilder(
+      column: $table.choavlm, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get choavl => $composableBuilder(
+      column: $table.choavl, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get choavldf => $composableBuilder(
+      column: $table.choavldf, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fib => $composableBuilder(
+      column: $table.fib, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get polyl => $composableBuilder(
+      column: $table.polyl, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get chocdf => $composableBuilder(
+      column: $table.chocdf, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get oa => $composableBuilder(
+      column: $table.oa, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get ash => $composableBuilder(
+      column: $table.ash, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get na => $composableBuilder(
+      column: $table.na, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get k => $composableBuilder(
+      column: $table.k, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get ca => $composableBuilder(
+      column: $table.ca, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get mg => $composableBuilder(
+      column: $table.mg, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get p => $composableBuilder(
+      column: $table.p, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fe => $composableBuilder(
+      column: $table.fe, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get zn => $composableBuilder(
+      column: $table.zn, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get cu => $composableBuilder(
+      column: $table.cu, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get mn => $composableBuilder(
+      column: $table.mn, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get iodine => $composableBuilder(
+      column: $table.iodine, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get se => $composableBuilder(
+      column: $table.se, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get cr => $composableBuilder(
+      column: $table.cr, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get mo => $composableBuilder(
+      column: $table.mo, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get retol => $composableBuilder(
+      column: $table.retol, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get carta => $composableBuilder(
+      column: $table.carta, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get cartb => $composableBuilder(
+      column: $table.cartb, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get crypxb => $composableBuilder(
+      column: $table.crypxb, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get cartbeq => $composableBuilder(
+      column: $table.cartbeq, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitaRae => $composableBuilder(
+      column: $table.vitaRae, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitD => $composableBuilder(
+      column: $table.vitD, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get tocphA => $composableBuilder(
+      column: $table.tocphA, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get tocphB => $composableBuilder(
+      column: $table.tocphB, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get tocphG => $composableBuilder(
+      column: $table.tocphG, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get tocphD => $composableBuilder(
+      column: $table.tocphD, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitK => $composableBuilder(
+      column: $table.vitK, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get thia => $composableBuilder(
+      column: $table.thia, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get ribf => $composableBuilder(
+      column: $table.ribf, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get nia => $composableBuilder(
+      column: $table.nia, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get ne => $composableBuilder(
+      column: $table.ne, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitB6A => $composableBuilder(
+      column: $table.vitB6A, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitB12 => $composableBuilder(
+      column: $table.vitB12, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get fol => $composableBuilder(
+      column: $table.fol, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get pantac => $composableBuilder(
+      column: $table.pantac, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get biot => $composableBuilder(
+      column: $table.biot, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get vitC => $composableBuilder(
+      column: $table.vitC, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get alc => $composableBuilder(
+      column: $table.alc, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get naclEq => $composableBuilder(
+      column: $table.naclEq, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$JapaneseFoodCompositionTableTableAnnotationComposer
+    extends Composer<_$AppDatabase, $JapaneseFoodCompositionTableTable> {
+  $$JapaneseFoodCompositionTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get groupId =>
+      $composableBuilder(column: $table.groupId, builder: (column) => column);
+
+  GeneratedColumn<int> get foodId =>
+      $composableBuilder(column: $table.foodId, builder: (column) => column);
+
+  GeneratedColumn<int> get indexId =>
+      $composableBuilder(column: $table.indexId, builder: (column) => column);
+
+  GeneratedColumn<String> get foodName =>
+      $composableBuilder(column: $table.foodName, builder: (column) => column);
+
+  GeneratedColumn<double> get refuse =>
+      $composableBuilder(column: $table.refuse, builder: (column) => column);
+
+  GeneratedColumn<double> get enerc =>
+      $composableBuilder(column: $table.enerc, builder: (column) => column);
+
+  GeneratedColumn<double> get enercKcal =>
+      $composableBuilder(column: $table.enercKcal, builder: (column) => column);
+
+  GeneratedColumn<double> get water =>
+      $composableBuilder(column: $table.water, builder: (column) => column);
+
+  GeneratedColumn<double> get protcaa =>
+      $composableBuilder(column: $table.protcaa, builder: (column) => column);
+
+  GeneratedColumn<double> get prot =>
+      $composableBuilder(column: $table.prot, builder: (column) => column);
+
+  GeneratedColumn<double> get fatnlea =>
+      $composableBuilder(column: $table.fatnlea, builder: (column) => column);
+
+  GeneratedColumn<double> get chole =>
+      $composableBuilder(column: $table.chole, builder: (column) => column);
+
+  GeneratedColumn<double> get fat =>
+      $composableBuilder(column: $table.fat, builder: (column) => column);
+
+  GeneratedColumn<double> get choavlm =>
+      $composableBuilder(column: $table.choavlm, builder: (column) => column);
+
+  GeneratedColumn<double> get choavl =>
+      $composableBuilder(column: $table.choavl, builder: (column) => column);
+
+  GeneratedColumn<double> get choavldf =>
+      $composableBuilder(column: $table.choavldf, builder: (column) => column);
+
+  GeneratedColumn<double> get fib =>
+      $composableBuilder(column: $table.fib, builder: (column) => column);
+
+  GeneratedColumn<double> get polyl =>
+      $composableBuilder(column: $table.polyl, builder: (column) => column);
+
+  GeneratedColumn<double> get chocdf =>
+      $composableBuilder(column: $table.chocdf, builder: (column) => column);
+
+  GeneratedColumn<double> get oa =>
+      $composableBuilder(column: $table.oa, builder: (column) => column);
+
+  GeneratedColumn<double> get ash =>
+      $composableBuilder(column: $table.ash, builder: (column) => column);
+
+  GeneratedColumn<double> get na =>
+      $composableBuilder(column: $table.na, builder: (column) => column);
+
+  GeneratedColumn<double> get k =>
+      $composableBuilder(column: $table.k, builder: (column) => column);
+
+  GeneratedColumn<double> get ca =>
+      $composableBuilder(column: $table.ca, builder: (column) => column);
+
+  GeneratedColumn<double> get mg =>
+      $composableBuilder(column: $table.mg, builder: (column) => column);
+
+  GeneratedColumn<double> get p =>
+      $composableBuilder(column: $table.p, builder: (column) => column);
+
+  GeneratedColumn<double> get fe =>
+      $composableBuilder(column: $table.fe, builder: (column) => column);
+
+  GeneratedColumn<double> get zn =>
+      $composableBuilder(column: $table.zn, builder: (column) => column);
+
+  GeneratedColumn<double> get cu =>
+      $composableBuilder(column: $table.cu, builder: (column) => column);
+
+  GeneratedColumn<double> get mn =>
+      $composableBuilder(column: $table.mn, builder: (column) => column);
+
+  GeneratedColumn<double> get iodine =>
+      $composableBuilder(column: $table.iodine, builder: (column) => column);
+
+  GeneratedColumn<double> get se =>
+      $composableBuilder(column: $table.se, builder: (column) => column);
+
+  GeneratedColumn<double> get cr =>
+      $composableBuilder(column: $table.cr, builder: (column) => column);
+
+  GeneratedColumn<double> get mo =>
+      $composableBuilder(column: $table.mo, builder: (column) => column);
+
+  GeneratedColumn<double> get retol =>
+      $composableBuilder(column: $table.retol, builder: (column) => column);
+
+  GeneratedColumn<double> get carta =>
+      $composableBuilder(column: $table.carta, builder: (column) => column);
+
+  GeneratedColumn<double> get cartb =>
+      $composableBuilder(column: $table.cartb, builder: (column) => column);
+
+  GeneratedColumn<double> get crypxb =>
+      $composableBuilder(column: $table.crypxb, builder: (column) => column);
+
+  GeneratedColumn<double> get cartbeq =>
+      $composableBuilder(column: $table.cartbeq, builder: (column) => column);
+
+  GeneratedColumn<double> get vitaRae =>
+      $composableBuilder(column: $table.vitaRae, builder: (column) => column);
+
+  GeneratedColumn<double> get vitD =>
+      $composableBuilder(column: $table.vitD, builder: (column) => column);
+
+  GeneratedColumn<double> get tocphA =>
+      $composableBuilder(column: $table.tocphA, builder: (column) => column);
+
+  GeneratedColumn<double> get tocphB =>
+      $composableBuilder(column: $table.tocphB, builder: (column) => column);
+
+  GeneratedColumn<double> get tocphG =>
+      $composableBuilder(column: $table.tocphG, builder: (column) => column);
+
+  GeneratedColumn<double> get tocphD =>
+      $composableBuilder(column: $table.tocphD, builder: (column) => column);
+
+  GeneratedColumn<double> get vitK =>
+      $composableBuilder(column: $table.vitK, builder: (column) => column);
+
+  GeneratedColumn<double> get thia =>
+      $composableBuilder(column: $table.thia, builder: (column) => column);
+
+  GeneratedColumn<double> get ribf =>
+      $composableBuilder(column: $table.ribf, builder: (column) => column);
+
+  GeneratedColumn<double> get nia =>
+      $composableBuilder(column: $table.nia, builder: (column) => column);
+
+  GeneratedColumn<double> get ne =>
+      $composableBuilder(column: $table.ne, builder: (column) => column);
+
+  GeneratedColumn<double> get vitB6A =>
+      $composableBuilder(column: $table.vitB6A, builder: (column) => column);
+
+  GeneratedColumn<double> get vitB12 =>
+      $composableBuilder(column: $table.vitB12, builder: (column) => column);
+
+  GeneratedColumn<double> get fol =>
+      $composableBuilder(column: $table.fol, builder: (column) => column);
+
+  GeneratedColumn<double> get pantac =>
+      $composableBuilder(column: $table.pantac, builder: (column) => column);
+
+  GeneratedColumn<double> get biot =>
+      $composableBuilder(column: $table.biot, builder: (column) => column);
+
+  GeneratedColumn<double> get vitC =>
+      $composableBuilder(column: $table.vitC, builder: (column) => column);
+
+  GeneratedColumn<double> get alc =>
+      $composableBuilder(column: $table.alc, builder: (column) => column);
+
+  GeneratedColumn<double> get naclEq =>
+      $composableBuilder(column: $table.naclEq, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$JapaneseFoodCompositionTableTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $JapaneseFoodCompositionTableTable,
+    JapaneseFoodCompositionTableData,
+    $$JapaneseFoodCompositionTableTableFilterComposer,
+    $$JapaneseFoodCompositionTableTableOrderingComposer,
+    $$JapaneseFoodCompositionTableTableAnnotationComposer,
+    $$JapaneseFoodCompositionTableTableCreateCompanionBuilder,
+    $$JapaneseFoodCompositionTableTableUpdateCompanionBuilder,
+    (
+      JapaneseFoodCompositionTableData,
+      BaseReferences<_$AppDatabase, $JapaneseFoodCompositionTableTable,
+          JapaneseFoodCompositionTableData>
+    ),
+    JapaneseFoodCompositionTableData,
+    PrefetchHooks Function()> {
+  $$JapaneseFoodCompositionTableTableTableManager(
+      _$AppDatabase db, $JapaneseFoodCompositionTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$JapaneseFoodCompositionTableTableFilterComposer(
+                  $db: db, $table: table),
+          createOrderingComposer: () =>
+              $$JapaneseFoodCompositionTableTableOrderingComposer(
+                  $db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$JapaneseFoodCompositionTableTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int> groupId = const Value.absent(),
+            Value<int> foodId = const Value.absent(),
+            Value<int> indexId = const Value.absent(),
+            Value<String> foodName = const Value.absent(),
+            Value<double> refuse = const Value.absent(),
+            Value<double?> enerc = const Value.absent(),
+            Value<double?> enercKcal = const Value.absent(),
+            Value<double?> water = const Value.absent(),
+            Value<double?> protcaa = const Value.absent(),
+            Value<double?> prot = const Value.absent(),
+            Value<double?> fatnlea = const Value.absent(),
+            Value<double?> chole = const Value.absent(),
+            Value<double?> fat = const Value.absent(),
+            Value<double?> choavlm = const Value.absent(),
+            Value<double?> choavl = const Value.absent(),
+            Value<double?> choavldf = const Value.absent(),
+            Value<double?> fib = const Value.absent(),
+            Value<double?> polyl = const Value.absent(),
+            Value<double?> chocdf = const Value.absent(),
+            Value<double?> oa = const Value.absent(),
+            Value<double?> ash = const Value.absent(),
+            Value<double?> na = const Value.absent(),
+            Value<double?> k = const Value.absent(),
+            Value<double?> ca = const Value.absent(),
+            Value<double?> mg = const Value.absent(),
+            Value<double?> p = const Value.absent(),
+            Value<double?> fe = const Value.absent(),
+            Value<double?> zn = const Value.absent(),
+            Value<double?> cu = const Value.absent(),
+            Value<double?> mn = const Value.absent(),
+            Value<double?> iodine = const Value.absent(),
+            Value<double?> se = const Value.absent(),
+            Value<double?> cr = const Value.absent(),
+            Value<double?> mo = const Value.absent(),
+            Value<double?> retol = const Value.absent(),
+            Value<double?> carta = const Value.absent(),
+            Value<double?> cartb = const Value.absent(),
+            Value<double?> crypxb = const Value.absent(),
+            Value<double?> cartbeq = const Value.absent(),
+            Value<double?> vitaRae = const Value.absent(),
+            Value<double?> vitD = const Value.absent(),
+            Value<double?> tocphA = const Value.absent(),
+            Value<double?> tocphB = const Value.absent(),
+            Value<double?> tocphG = const Value.absent(),
+            Value<double?> tocphD = const Value.absent(),
+            Value<double?> vitK = const Value.absent(),
+            Value<double?> thia = const Value.absent(),
+            Value<double?> ribf = const Value.absent(),
+            Value<double?> nia = const Value.absent(),
+            Value<double?> ne = const Value.absent(),
+            Value<double?> vitB6A = const Value.absent(),
+            Value<double?> vitB12 = const Value.absent(),
+            Value<double?> fol = const Value.absent(),
+            Value<double?> pantac = const Value.absent(),
+            Value<double?> biot = const Value.absent(),
+            Value<double?> vitC = const Value.absent(),
+            Value<double?> alc = const Value.absent(),
+            Value<double?> naclEq = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              JapaneseFoodCompositionTableCompanion(
+            id: id,
+            groupId: groupId,
+            foodId: foodId,
+            indexId: indexId,
+            foodName: foodName,
+            refuse: refuse,
+            enerc: enerc,
+            enercKcal: enercKcal,
+            water: water,
+            protcaa: protcaa,
+            prot: prot,
+            fatnlea: fatnlea,
+            chole: chole,
+            fat: fat,
+            choavlm: choavlm,
+            choavl: choavl,
+            choavldf: choavldf,
+            fib: fib,
+            polyl: polyl,
+            chocdf: chocdf,
+            oa: oa,
+            ash: ash,
+            na: na,
+            k: k,
+            ca: ca,
+            mg: mg,
+            p: p,
+            fe: fe,
+            zn: zn,
+            cu: cu,
+            mn: mn,
+            iodine: iodine,
+            se: se,
+            cr: cr,
+            mo: mo,
+            retol: retol,
+            carta: carta,
+            cartb: cartb,
+            crypxb: crypxb,
+            cartbeq: cartbeq,
+            vitaRae: vitaRae,
+            vitD: vitD,
+            tocphA: tocphA,
+            tocphB: tocphB,
+            tocphG: tocphG,
+            tocphD: tocphD,
+            vitK: vitK,
+            thia: thia,
+            ribf: ribf,
+            nia: nia,
+            ne: ne,
+            vitB6A: vitB6A,
+            vitB12: vitB12,
+            fol: fol,
+            pantac: pantac,
+            biot: biot,
+            vitC: vitC,
+            alc: alc,
+            naclEq: naclEq,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required int groupId,
+            required int foodId,
+            required int indexId,
+            required String foodName,
+            Value<double> refuse = const Value.absent(),
+            Value<double?> enerc = const Value.absent(),
+            Value<double?> enercKcal = const Value.absent(),
+            Value<double?> water = const Value.absent(),
+            Value<double?> protcaa = const Value.absent(),
+            Value<double?> prot = const Value.absent(),
+            Value<double?> fatnlea = const Value.absent(),
+            Value<double?> chole = const Value.absent(),
+            Value<double?> fat = const Value.absent(),
+            Value<double?> choavlm = const Value.absent(),
+            Value<double?> choavl = const Value.absent(),
+            Value<double?> choavldf = const Value.absent(),
+            Value<double?> fib = const Value.absent(),
+            Value<double?> polyl = const Value.absent(),
+            Value<double?> chocdf = const Value.absent(),
+            Value<double?> oa = const Value.absent(),
+            Value<double?> ash = const Value.absent(),
+            Value<double?> na = const Value.absent(),
+            Value<double?> k = const Value.absent(),
+            Value<double?> ca = const Value.absent(),
+            Value<double?> mg = const Value.absent(),
+            Value<double?> p = const Value.absent(),
+            Value<double?> fe = const Value.absent(),
+            Value<double?> zn = const Value.absent(),
+            Value<double?> cu = const Value.absent(),
+            Value<double?> mn = const Value.absent(),
+            Value<double?> iodine = const Value.absent(),
+            Value<double?> se = const Value.absent(),
+            Value<double?> cr = const Value.absent(),
+            Value<double?> mo = const Value.absent(),
+            Value<double?> retol = const Value.absent(),
+            Value<double?> carta = const Value.absent(),
+            Value<double?> cartb = const Value.absent(),
+            Value<double?> crypxb = const Value.absent(),
+            Value<double?> cartbeq = const Value.absent(),
+            Value<double?> vitaRae = const Value.absent(),
+            Value<double?> vitD = const Value.absent(),
+            Value<double?> tocphA = const Value.absent(),
+            Value<double?> tocphB = const Value.absent(),
+            Value<double?> tocphG = const Value.absent(),
+            Value<double?> tocphD = const Value.absent(),
+            Value<double?> vitK = const Value.absent(),
+            Value<double?> thia = const Value.absent(),
+            Value<double?> ribf = const Value.absent(),
+            Value<double?> nia = const Value.absent(),
+            Value<double?> ne = const Value.absent(),
+            Value<double?> vitB6A = const Value.absent(),
+            Value<double?> vitB12 = const Value.absent(),
+            Value<double?> fol = const Value.absent(),
+            Value<double?> pantac = const Value.absent(),
+            Value<double?> biot = const Value.absent(),
+            Value<double?> vitC = const Value.absent(),
+            Value<double?> alc = const Value.absent(),
+            Value<double?> naclEq = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              JapaneseFoodCompositionTableCompanion.insert(
+            id: id,
+            groupId: groupId,
+            foodId: foodId,
+            indexId: indexId,
+            foodName: foodName,
+            refuse: refuse,
+            enerc: enerc,
+            enercKcal: enercKcal,
+            water: water,
+            protcaa: protcaa,
+            prot: prot,
+            fatnlea: fatnlea,
+            chole: chole,
+            fat: fat,
+            choavlm: choavlm,
+            choavl: choavl,
+            choavldf: choavldf,
+            fib: fib,
+            polyl: polyl,
+            chocdf: chocdf,
+            oa: oa,
+            ash: ash,
+            na: na,
+            k: k,
+            ca: ca,
+            mg: mg,
+            p: p,
+            fe: fe,
+            zn: zn,
+            cu: cu,
+            mn: mn,
+            iodine: iodine,
+            se: se,
+            cr: cr,
+            mo: mo,
+            retol: retol,
+            carta: carta,
+            cartb: cartb,
+            crypxb: crypxb,
+            cartbeq: cartbeq,
+            vitaRae: vitaRae,
+            vitD: vitD,
+            tocphA: tocphA,
+            tocphB: tocphB,
+            tocphG: tocphG,
+            tocphD: tocphD,
+            vitK: vitK,
+            thia: thia,
+            ribf: ribf,
+            nia: nia,
+            ne: ne,
+            vitB6A: vitB6A,
+            vitB12: vitB12,
+            fol: fol,
+            pantac: pantac,
+            biot: biot,
+            vitC: vitC,
+            alc: alc,
+            naclEq: naclEq,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$JapaneseFoodCompositionTableTableProcessedTableManager
+    = ProcessedTableManager<
+        _$AppDatabase,
+        $JapaneseFoodCompositionTableTable,
+        JapaneseFoodCompositionTableData,
+        $$JapaneseFoodCompositionTableTableFilterComposer,
+        $$JapaneseFoodCompositionTableTableOrderingComposer,
+        $$JapaneseFoodCompositionTableTableAnnotationComposer,
+        $$JapaneseFoodCompositionTableTableCreateCompanionBuilder,
+        $$JapaneseFoodCompositionTableTableUpdateCompanionBuilder,
+        (
+          JapaneseFoodCompositionTableData,
+          BaseReferences<_$AppDatabase, $JapaneseFoodCompositionTableTable,
+              JapaneseFoodCompositionTableData>
+        ),
+        JapaneseFoodCompositionTableData,
+        PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -5786,4 +8967,8 @@ class $AppDatabaseManager {
       $$FoodItemTableTableTableManager(_db, _db.foodItemTable);
   $$RecipeTableTableTableManager get recipeTable =>
       $$RecipeTableTableTableManager(_db, _db.recipeTable);
+  $$JapaneseFoodCompositionTableTableTableManager
+      get japaneseFoodCompositionTable =>
+          $$JapaneseFoodCompositionTableTableTableManager(
+              _db, _db.japaneseFoodCompositionTable);
 }

--- a/lib/data/models/food_mapping_table.dart
+++ b/lib/data/models/food_mapping_table.dart
@@ -1,0 +1,134 @@
+import 'package:drift/drift.dart';
+import 'nutrition_table.dart';
+
+/// 食品マッピングテーブル（材料名 → 栄養データの対応）
+@UseRowClass(FoodMappingTableData)
+class FoodMappingTable extends Table {
+  /// ID
+  IntColumn get id => integer().autoIncrement()();
+  
+  /// 材料名（レシピで使われる一般的な名前）
+  TextColumn get ingredientName => text()();
+  
+  /// 栄養データテーブルのID
+  IntColumn get nutritionDataId => integer().references(NutritionDataTable, #id)();
+  
+  /// マッピングの信頼度（0.0-1.0）
+  RealColumn get confidence => real().withDefault(const Constant(1.0))();
+  
+  /// 単位変換係数（材料の単位からg換算）
+  /// 例: 玉ねぎ1個 = 200g なら 200.0
+  RealColumn get unitConversionFactor => real().nullable()();
+  
+  /// 単位名
+  TextColumn get unit => text().nullable()();
+  
+  /// 別名・類義語（カンマ区切り）
+  TextColumn get aliases => text().nullable()();
+  
+  /// カテゴリ（野菜、肉類、調味料など）
+  TextColumn get category => text().nullable()();
+  
+  /// 廃棄率調整後の可食部割合（0.0-1.0）
+  RealColumn get ediblePortion => real().withDefault(const Constant(1.0))();
+  
+  /// 作成日
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  
+  /// 更新日
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+/// 食品マッピングデータクラス
+class FoodMappingTableData {
+  final int id;
+  final String ingredientName;
+  final int nutritionDataId;
+  final double confidence;
+  final double? unitConversionFactor;
+  final String? unit;
+  final String? aliases;
+  final String? category;
+  final double ediblePortion;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const FoodMappingTableData({
+    required this.id,
+    required this.ingredientName,
+    required this.nutritionDataId,
+    required this.confidence,
+    this.unitConversionFactor,
+    this.unit,
+    this.aliases,
+    this.category,
+    required this.ediblePortion,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  /// 別名リストの取得
+  List<String> getAliases() {
+    if (aliases == null || aliases!.isEmpty) return [];
+    return aliases!.split(',').map((e) => e.trim()).toList();
+  }
+
+  /// 材料名がマッチするかチェック
+  bool matchesIngredient(String name) {
+    final normalizedName = name.toLowerCase().trim();
+    final normalizedIngredientName = ingredientName.toLowerCase().trim();
+    
+    // 完全一致
+    if (normalizedName == normalizedIngredientName) return true;
+    
+    // 部分一致
+    if (normalizedName.contains(normalizedIngredientName) || 
+        normalizedIngredientName.contains(normalizedName)) return true;
+    
+    // 別名チェック
+    final aliasesList = getAliases();
+    for (final alias in aliasesList) {
+      final normalizedAlias = alias.toLowerCase().trim();
+      if (normalizedName == normalizedAlias ||
+          normalizedName.contains(normalizedAlias) ||
+          normalizedAlias.contains(normalizedName)) return true;
+    }
+    
+    return false;
+  }
+
+  /// 単位からグラムへの変換
+  double convertToGrams(double amount, String? inputUnit) {
+    // 単位変換係数が設定されている場合
+    if (unitConversionFactor != null && inputUnit == unit) {
+      return amount * unitConversionFactor!;
+    }
+    
+    // 一般的な単位変換
+    final normalizedUnit = (inputUnit ?? '').toLowerCase();
+    switch (normalizedUnit) {
+      case 'kg':
+      case 'キロ':
+        return amount * 1000;
+      case 'g':
+      case 'グラム':
+        return amount;
+      case '個':
+      case 'コ':
+        // デフォルトの単位変換係数を使用
+        return amount * (unitConversionFactor ?? 100.0);
+      case '本':
+        return amount * (unitConversionFactor ?? 50.0);
+      case '枚':
+        return amount * (unitConversionFactor ?? 20.0);
+      case '束':
+        return amount * (unitConversionFactor ?? 100.0);
+      case '片':
+        return amount * (unitConversionFactor ?? 10.0);
+      case '玉':
+        return amount * (unitConversionFactor ?? 200.0);
+      default:
+        return amount;
+    }
+  }
+}

--- a/lib/data/models/japanese_food_composition_table.dart
+++ b/lib/data/models/japanese_food_composition_table.dart
@@ -1,0 +1,452 @@
+import 'package:drift/drift.dart';
+
+/// 日本食品標準成分表2020年版データテーブル
+/// katoharu432さんのJSONデータに対応
+@UseRowClass(JapaneseFoodCompositionTableData)
+class JapaneseFoodCompositionTable extends Table {
+  /// 内部ID
+  IntColumn get id => integer().autoIncrement()();
+  
+  /// 食品群ID
+  IntColumn get groupId => integer()();
+  
+  /// 食品ID
+  IntColumn get foodId => integer().unique()();
+  
+  /// インデックスID
+  IntColumn get indexId => integer()();
+  
+  /// 食品名
+  TextColumn get foodName => text()();
+  
+  /// 廃棄率(%)
+  RealColumn get refuse => real().withDefault(const Constant(0.0))();
+  
+  // エネルギー
+  /// エネルギー（kJ/100g）
+  RealColumn get enerc => real().nullable()();
+  
+  /// エネルギー（kcal/100g）
+  RealColumn get enercKcal => real().nullable()();
+  
+  // 基本栄養素
+  /// 水分（g/100g）
+  RealColumn get water => real().nullable()();
+  
+  /// たんぱく質（アミノ酸組成によるもの）（g/100g）
+  RealColumn get protcaa => real().nullable()();
+  
+  /// たんぱく質（g/100g）
+  RealColumn get prot => real().nullable()();
+  
+  /// 脂質（トリアシルグリセロール当量）（g/100g）
+  RealColumn get fatnlea => real().nullable()();
+  
+  /// コレステロール（mg/100g）
+  RealColumn get chole => real().nullable()();
+  
+  /// 脂質（g/100g）
+  RealColumn get fat => real().nullable()();
+  
+  // 炭水化物
+  /// 利用可能炭水化物（単糖当量）（g/100g）
+  RealColumn get choavlm => real().nullable()();
+  
+  /// 利用可能炭水化物（g/100g）
+  RealColumn get choavl => real().nullable()();
+  
+  /// 利用可能炭水化物（でん粉・糖類）（g/100g）
+  RealColumn get choavldf => real().nullable()();
+  
+  /// 総食物繊維（g/100g）
+  RealColumn get fib => real().nullable()();
+  
+  /// 多糖類（g/100g）
+  RealColumn get polyl => real().nullable()();
+  
+  /// 炭水化物（g/100g）
+  RealColumn get chocdf => real().nullable()();
+  
+  /// 有機酸（g/100g）
+  RealColumn get oa => real().nullable()();
+  
+  /// 灰分（g/100g）
+  RealColumn get ash => real().nullable()();
+  
+  // ミネラル
+  /// ナトリウム（mg/100g）
+  RealColumn get na => real().nullable()();
+  
+  /// カリウム（mg/100g）
+  RealColumn get k => real().nullable()();
+  
+  /// カルシウム（mg/100g）
+  RealColumn get ca => real().nullable()();
+  
+  /// マグネシウム（mg/100g）
+  RealColumn get mg => real().nullable()();
+  
+  /// リン（mg/100g）
+  RealColumn get p => real().nullable()();
+  
+  /// 鉄（mg/100g）
+  RealColumn get fe => real().nullable()();
+  
+  /// 亜鉛（mg/100g）
+  RealColumn get zn => real().nullable()();
+  
+  /// 銅（mg/100g）
+  RealColumn get cu => real().nullable()();
+  
+  /// マンガン（mg/100g）
+  RealColumn get mn => real().nullable()();
+  
+  /// ヨウ素（μg/100g）- 注意：keyが'id'のため'iodine'として保存
+  RealColumn get iodine => real().nullable()();
+  
+  /// セレン（μg/100g）
+  RealColumn get se => real().nullable()();
+  
+  /// クロム（μg/100g）
+  RealColumn get cr => real().nullable()();
+  
+  /// モリブデン（μg/100g）
+  RealColumn get mo => real().nullable()();
+  
+  // ビタミンA系
+  /// レチノール（μg/100g）
+  RealColumn get retol => real().nullable()();
+  
+  /// αカロテン（μg/100g）
+  RealColumn get carta => real().nullable()();
+  
+  /// βカロテン（μg/100g）
+  RealColumn get cartb => real().nullable()();
+  
+  /// βクリプトキサンチン（μg/100g）
+  RealColumn get crypxb => real().nullable()();
+  
+  /// βカロテン当量（μg/100g）
+  RealColumn get cartbeq => real().nullable()();
+  
+  /// レチノール活性当量（μg/100g）
+  RealColumn get vitaRae => real().nullable()();
+  
+  // ビタミンD
+  /// ビタミンD（μg/100g）
+  RealColumn get vitD => real().nullable()();
+  
+  // ビタミンE
+  /// αトコフェロール（mg/100g）
+  RealColumn get tocphA => real().nullable()();
+  
+  /// βトコフェロール（mg/100g）
+  RealColumn get tocphB => real().nullable()();
+  
+  /// γトコフェロール（mg/100g）
+  RealColumn get tocphG => real().nullable()();
+  
+  /// δトコフェロール（mg/100g）
+  RealColumn get tocphD => real().nullable()();
+  
+  // ビタミンK
+  /// ビタミンK（μg/100g）
+  RealColumn get vitK => real().nullable()();
+  
+  // ビタミンB群
+  /// ビタミンB1（mg/100g）
+  RealColumn get thia => real().nullable()();
+  
+  /// ビタミンB2（mg/100g）
+  RealColumn get ribf => real().nullable()();
+  
+  /// ナイアシン（mg/100g）
+  RealColumn get nia => real().nullable()();
+  
+  /// ナイアシン当量（mg/100g）
+  RealColumn get ne => real().nullable()();
+  
+  /// ビタミンB6（mg/100g）
+  RealColumn get vitB6A => real().nullable()();
+  
+  /// ビタミンB12（μg/100g）
+  RealColumn get vitB12 => real().nullable()();
+  
+  /// 葉酸（μg/100g）
+  RealColumn get fol => real().nullable()();
+  
+  /// パントテン酸（mg/100g）
+  RealColumn get pantac => real().nullable()();
+  
+  /// ビオチン（μg/100g）
+  RealColumn get biot => real().nullable()();
+  
+  // ビタミンC
+  /// ビタミンC（mg/100g）
+  RealColumn get vitC => real().nullable()();
+  
+  // その他
+  /// アルコール（g/100g）
+  RealColumn get alc => real().nullable()();
+  
+  /// 食塩相当量（g/100g）
+  RealColumn get naclEq => real().nullable()();
+  
+  /// データ作成日
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  
+  /// データ更新日
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+/// 日本食品標準成分表データクラス
+class JapaneseFoodCompositionTableData {
+  final int id;
+  final int groupId;
+  final int foodId;
+  final int indexId;
+  final String foodName;
+  final double refuse;
+  final double? enerc;
+  final double? enercKcal;
+  final double? water;
+  final double? protcaa;
+  final double? prot;
+  final double? fatnlea;
+  final double? chole;
+  final double? fat;
+  final double? choavlm;
+  final double? choavl;
+  final double? choavldf;
+  final double? fib;
+  final double? polyl;
+  final double? chocdf;
+  final double? oa;
+  final double? ash;
+  final double? na;
+  final double? k;
+  final double? ca;
+  final double? mg;
+  final double? p;
+  final double? fe;
+  final double? zn;
+  final double? cu;
+  final double? mn;
+  final double? iodine;
+  final double? se;
+  final double? cr;
+  final double? mo;
+  final double? retol;
+  final double? carta;
+  final double? cartb;
+  final double? crypxb;
+  final double? cartbeq;
+  final double? vitaRae;
+  final double? vitD;
+  final double? tocphA;
+  final double? tocphB;
+  final double? tocphG;
+  final double? tocphD;
+  final double? vitK;
+  final double? thia;
+  final double? ribf;
+  final double? nia;
+  final double? ne;
+  final double? vitB6A;
+  final double? vitB12;
+  final double? fol;
+  final double? pantac;
+  final double? biot;
+  final double? vitC;
+  final double? alc;
+  final double? naclEq;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const JapaneseFoodCompositionTableData({
+    required this.id,
+    required this.groupId,
+    required this.foodId,
+    required this.indexId,
+    required this.foodName,
+    required this.refuse,
+    this.enerc,
+    this.enercKcal,
+    this.water,
+    this.protcaa,
+    this.prot,
+    this.fatnlea,
+    this.chole,
+    this.fat,
+    this.choavlm,
+    this.choavl,
+    this.choavldf,
+    this.fib,
+    this.polyl,
+    this.chocdf,
+    this.oa,
+    this.ash,
+    this.na,
+    this.k,
+    this.ca,
+    this.mg,
+    this.p,
+    this.fe,
+    this.zn,
+    this.cu,
+    this.mn,
+    this.iodine,
+    this.se,
+    this.cr,
+    this.mo,
+    this.retol,
+    this.carta,
+    this.cartb,
+    this.crypxb,
+    this.cartbeq,
+    this.vitaRae,
+    this.vitD,
+    this.tocphA,
+    this.tocphB,
+    this.tocphG,
+    this.tocphD,
+    this.vitK,
+    this.thia,
+    this.ribf,
+    this.nia,
+    this.ne,
+    this.vitB6A,
+    this.vitB12,
+    this.fol,
+    this.pantac,
+    this.biot,
+    this.vitC,
+    this.alc,
+    this.naclEq,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  /// 基本栄養素（カロリー、タンパク質、脂質、炭水化物）の取得
+  Map<String, double> getBasicNutrition() {
+    return {
+      'energy': enercKcal ?? 0.0,
+      'protein': prot ?? 0.0, // protcaaよりprotを優先
+      'fat': fat ?? 0.0,
+      'carbohydrate': choavl ?? chocdf ?? 0.0, // 利用可能炭水化物を優先
+    };
+  }
+
+  /// ミネラル情報の取得
+  Map<String, double> getMinerals() {
+    return {
+      'sodium': na ?? 0.0,
+      'potassium': k ?? 0.0,
+      'calcium': ca ?? 0.0,
+      'magnesium': mg ?? 0.0,
+      'phosphorus': p ?? 0.0,
+      'iron': fe ?? 0.0,
+      'zinc': zn ?? 0.0,
+      'copper': cu ?? 0.0,
+      'manganese': mn ?? 0.0,
+      'iodine': iodine ?? 0.0,
+      'selenium': se ?? 0.0,
+    };
+  }
+
+  /// ビタミン情報の取得
+  Map<String, double> getVitamins() {
+    return {
+      'vitaminA': vitaRae ?? cartbeq ?? 0.0, // レチノール活性当量を優先
+      'vitaminD': vitD ?? 0.0,
+      'vitaminE': tocphA ?? 0.0,
+      'vitaminK': vitK ?? 0.0,
+      'vitaminB1': thia ?? 0.0,
+      'vitaminB2': ribf ?? 0.0,
+      'niacin': nia ?? 0.0,
+      'vitaminB6': vitB6A ?? 0.0,
+      'vitaminB12': vitB12 ?? 0.0,
+      'folate': fol ?? 0.0,
+      'pantothenicAcid': pantac ?? 0.0,
+      'biotin': biot ?? 0.0,
+      'vitaminC': vitC ?? 0.0,
+    };
+  }
+
+  /// 食物繊維情報の取得
+  double getDietaryFiber() {
+    return fib ?? 0.0;
+  }
+
+  /// 食塩相当量の取得
+  double getSaltEquivalent() {
+    return naclEq ?? (na != null ? na! * 2.54 / 1000 : 0.0); // ナトリウムから計算
+  }
+
+  /// JSONからオブジェクトを生成
+  factory JapaneseFoodCompositionTableData.fromJson(Map<String, dynamic> json) {
+    return JapaneseFoodCompositionTableData(
+      id: 0, // auto-increment
+      groupId: json['groupId'] ?? 0,
+      foodId: json['foodId'] ?? 0,
+      indexId: json['indexId'] ?? 0,
+      foodName: json['foodName'] ?? '',
+      refuse: (json['refuse'] ?? 0).toDouble(),
+      enerc: json['enerc']?.toDouble(),
+      enercKcal: json['enercKcal']?.toDouble(),
+      water: json['water']?.toDouble(),
+      protcaa: json['protcaa']?.toDouble(),
+      prot: json['prot']?.toDouble(),
+      fatnlea: json['fatnlea']?.toDouble(),
+      chole: json['chole']?.toDouble(),
+      fat: json['fat']?.toDouble(),
+      choavlm: json['choavlm']?.toDouble(),
+      choavl: json['choavl']?.toDouble(),
+      choavldf: json['choavldf']?.toDouble(),
+      fib: json['fib']?.toDouble(),
+      polyl: json['polyl']?.toDouble(),
+      chocdf: json['chocdf']?.toDouble(),
+      oa: json['oa']?.toDouble(),
+      ash: json['ash']?.toDouble(),
+      na: json['na']?.toDouble(),
+      k: json['k']?.toDouble(),
+      ca: json['ca']?.toDouble(),
+      mg: json['mg']?.toDouble(),
+      p: json['p']?.toDouble(),
+      fe: json['fe']?.toDouble(),
+      zn: json['zn']?.toDouble(),
+      cu: json['cu']?.toDouble(),
+      mn: json['mn']?.toDouble(),
+      iodine: json['id']?.toDouble(), // JSONのkeyは'id'だがiodineとして保存
+      se: json['se']?.toDouble(),
+      cr: json['cr']?.toDouble(),
+      mo: json['mo']?.toDouble(),
+      retol: json['retol']?.toDouble(),
+      carta: json['carta']?.toDouble(),
+      cartb: json['cartb']?.toDouble(),
+      crypxb: json['crypxb']?.toDouble(),
+      cartbeq: json['cartbeq']?.toDouble(),
+      vitaRae: json['vitaRae']?.toDouble(),
+      vitD: json['vitD']?.toDouble(),
+      tocphA: json['tocphA']?.toDouble(),
+      tocphB: json['tocphB']?.toDouble(),
+      tocphG: json['tocphG']?.toDouble(),
+      tocphD: json['tocphD']?.toDouble(),
+      vitK: json['vitK']?.toDouble(),
+      thia: json['thia']?.toDouble(),
+      ribf: json['ribf']?.toDouble(),
+      nia: json['nia']?.toDouble(),
+      ne: json['ne']?.toDouble(),
+      vitB6A: json['vitB6A']?.toDouble(),
+      vitB12: json['vitB12']?.toDouble(),
+      fol: json['fol']?.toDouble(),
+      pantac: json['pantac']?.toDouble(),
+      biot: json['biot']?.toDouble(),
+      vitC: json['vitC']?.toDouble(),
+      alc: json['alc']?.toDouble(),
+      naclEq: json['naclEq']?.toDouble(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+  }
+}

--- a/lib/data/models/meal_table.dart
+++ b/lib/data/models/meal_table.dart
@@ -101,6 +101,39 @@ class ExternalRecipeTable extends Table {
   /// メモ
   TextColumn get memo => text().nullable()();
   
+  /// 材料情報（JSON形式）
+  TextColumn get ingredientsJson => text().nullable()();
+  
+  /// 抽出された材料の生テキスト
+  TextColumn get ingredientsRawText => text().nullable()();
+  
+  /// 栄養情報（カロリー/1人前）
+  RealColumn get calories => real().nullable()();
+  
+  /// タンパク質（g/1人前）
+  RealColumn get protein => real().nullable()();
+  
+  /// 脂質（g/1人前）
+  RealColumn get fat => real().nullable()();
+  
+  /// 炭水化物（g/1人前）
+  RealColumn get carbohydrate => real().nullable()();
+  
+  /// 食塩相当量（g/1人前）
+  RealColumn get salt => real().nullable()();
+  
+  /// 食物繊維（g/1人前）
+  RealColumn get fiber => real().nullable()();
+  
+  /// ビタミンC（mg/1人前）
+  RealColumn get vitaminC => real().nullable()();
+  
+  /// 材料・栄養情報が自動推測されたかのフラグ
+  BoolColumn get isNutritionAutoExtracted => boolean().withDefault(const Constant(false))();
+  
+  /// 人数（栄養計算の基準）
+  IntColumn get servings => integer().withDefault(const Constant(1))();
+  
   /// 最終アクセス日時
   DateTimeColumn get lastAccessedAt => dateTime().nullable()();
   

--- a/lib/data/models/nutrition_table.dart
+++ b/lib/data/models/nutrition_table.dart
@@ -1,0 +1,339 @@
+import 'package:drift/drift.dart';
+
+/// 栄養成分データテーブル（日本食品標準成分表2020年版ベース）
+@UseRowClass(NutritionDataTableData)
+class NutritionDataTable extends Table {
+  /// 内部ID
+  IntColumn get id => integer().autoIncrement()();
+  
+  /// 食品群ID
+  IntColumn get groupId => integer()();
+  
+  /// 食品ID
+  IntColumn get foodId => integer().unique()();
+  
+  /// インデックスID
+  IntColumn get indexId => integer()();
+  
+  /// 食品名
+  TextColumn get foodName => text()();
+  
+  /// 廃棄率(%)
+  RealColumn get refuse => real().withDefault(const Constant(0.0))();
+  
+  /// エネルギー（kcal/100g）
+  RealColumn get energy => real().nullable()();
+  
+  /// 水分（g/100g）
+  RealColumn get water => real().nullable()();
+  
+  /// たんぱく質（g/100g）
+  RealColumn get protein => real().nullable()();
+  
+  /// 脂質（g/100g）
+  RealColumn get fat => real().nullable()();
+  
+  /// 炭水化物（g/100g）
+  RealColumn get carbohydrate => real().nullable()();
+  
+  /// 灰分（g/100g）
+  RealColumn get ash => real().nullable()();
+  
+  /// ナトリウム（mg/100g）
+  RealColumn get sodium => real().nullable()();
+  
+  /// カリウム（mg/100g）
+  RealColumn get potassium => real().nullable()();
+  
+  /// カルシウム（mg/100g）
+  RealColumn get calcium => real().nullable()();
+  
+  /// マグネシウム（mg/100g）
+  RealColumn get magnesium => real().nullable()();
+  
+  /// リン（mg/100g）
+  RealColumn get phosphorus => real().nullable()();
+  
+  /// 鉄（mg/100g）
+  RealColumn get iron => real().nullable()();
+  
+  /// 亜鉛（mg/100g）
+  RealColumn get zinc => real().nullable()();
+  
+  /// 銅（mg/100g）
+  RealColumn get copper => real().nullable()();
+  
+  /// マンガン（mg/100g）
+  RealColumn get manganese => real().nullable()();
+  
+  /// ヨウ素（μg/100g）
+  RealColumn get iodine => real().nullable()();
+  
+  /// セレン（μg/100g）
+  RealColumn get selenium => real().nullable()();
+  
+  /// クロム（μg/100g）
+  RealColumn get chromium => real().nullable()();
+  
+  /// モリブデン（μg/100g）
+  RealColumn get molybdenum => real().nullable()();
+  
+  /// レチノール（μg/100g）
+  RealColumn get retinol => real().nullable()();
+  
+  /// αカロテン（μg/100g）
+  RealColumn get alphaCarotene => real().nullable()();
+  
+  /// βカロテン（μg/100g）
+  RealColumn get betaCarotene => real().nullable()();
+  
+  /// βクリプトキサンチン（μg/100g）
+  RealColumn get betaCryptoxanthin => real().nullable()();
+  
+  /// βカロテン当量（μg/100g）
+  RealColumn get betaCaroteneEquivalent => real().nullable()();
+  
+  /// レチノール活性当量（μg/100g）
+  RealColumn get retinolActivityEquivalent => real().nullable()();
+  
+  /// ビタミンD（μg/100g）
+  RealColumn get vitaminD => real().nullable()();
+  
+  /// αトコフェロール（mg/100g）
+  RealColumn get alphaTocopherol => real().nullable()();
+  
+  /// βトコフェロール（mg/100g）
+  RealColumn get betaTocopherol => real().nullable()();
+  
+  /// γトコフェロール（mg/100g）
+  RealColumn get gammaTocopherol => real().nullable()();
+  
+  /// δトコフェロール（mg/100g）
+  RealColumn get deltaTocopherol => real().nullable()();
+  
+  /// ビタミンK（μg/100g）
+  RealColumn get vitaminK => real().nullable()();
+  
+  /// ビタミンB1（mg/100g）
+  RealColumn get vitaminB1 => real().nullable()();
+  
+  /// ビタミンB2（mg/100g）
+  RealColumn get vitaminB2 => real().nullable()();
+  
+  /// ナイアシン（mg/100g）
+  RealColumn get niacin => real().nullable()();
+  
+  /// ビタミンB6（mg/100g）
+  RealColumn get vitaminB6 => real().nullable()();
+  
+  /// ビタミンB12（μg/100g）
+  RealColumn get vitaminB12 => real().nullable()();
+  
+  /// 葉酸（μg/100g）
+  RealColumn get folate => real().nullable()();
+  
+  /// パントテン酸（mg/100g）
+  RealColumn get pantothenicAcid => real().nullable()();
+  
+  /// ビオチン（μg/100g）
+  RealColumn get biotin => real().nullable()();
+  
+  /// ビタミンC（mg/100g）
+  RealColumn get vitaminC => real().nullable()();
+  
+  /// 食塩相当量（g/100g）
+  RealColumn get saltEquivalent => real().nullable()();
+  
+  /// 飽和脂肪酸（g/100g）
+  RealColumn get saturatedFat => real().nullable()();
+  
+  /// 一価不飽和脂肪酸（g/100g）
+  RealColumn get monounsaturatedFat => real().nullable()();
+  
+  /// 多価不飽和脂肪酸（g/100g）
+  RealColumn get polyunsaturatedFat => real().nullable()();
+  
+  /// コレステロール（mg/100g）
+  RealColumn get cholesterol => real().nullable()();
+  
+  /// 食物繊維総量（g/100g）
+  RealColumn get dietaryFiber => real().nullable()();
+  
+  /// 水溶性食物繊維（g/100g）
+  RealColumn get solubleFiber => real().nullable()();
+  
+  /// 不溶性食物繊維（g/100g）
+  RealColumn get insolubleFiber => real().nullable()();
+  
+  /// 有機酸（g/100g）
+  RealColumn get organicAcid => real().nullable()();
+  
+  /// 廃棄率（%）
+  RealColumn get wasteRate => real().nullable()();
+  
+  /// データ作成日
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  
+  /// データ更新日
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+/// 栄養成分データクラス
+class NutritionDataTableData {
+  final int id;
+  final String foodNumber;
+  final String foodName;
+  final String? foodNameKana;
+  final String? foodGroup;
+  final String? category;
+  final double? energy;
+  final double? water;
+  final double? protein;
+  final double? fat;
+  final double? carbohydrate;
+  final double? ash;
+  final double? sodium;
+  final double? potassium;
+  final double? calcium;
+  final double? magnesium;
+  final double? phosphorus;
+  final double? iron;
+  final double? zinc;
+  final double? copper;
+  final double? manganese;
+  final double? iodine;
+  final double? selenium;
+  final double? chromium;
+  final double? molybdenum;
+  final double? retinol;
+  final double? alphaCarotene;
+  final double? betaCarotene;
+  final double? betaCryptoxanthin;
+  final double? betaCaroteneEquivalent;
+  final double? retinolActivityEquivalent;
+  final double? vitaminD;
+  final double? alphaTocopherol;
+  final double? betaTocopherol;
+  final double? gammaTocopherol;
+  final double? deltaTocopherol;
+  final double? vitaminK;
+  final double? vitaminB1;
+  final double? vitaminB2;
+  final double? niacin;
+  final double? vitaminB6;
+  final double? vitaminB12;
+  final double? folate;
+  final double? pantothenicAcid;
+  final double? biotin;
+  final double? vitaminC;
+  final double? saltEquivalent;
+  final double? saturatedFat;
+  final double? monounsaturatedFat;
+  final double? polyunsaturatedFat;
+  final double? cholesterol;
+  final double? dietaryFiber;
+  final double? solubleFiber;
+  final double? insolubleFiber;
+  final double? organicAcid;
+  final double? wasteRate;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const NutritionDataTableData({
+    required this.id,
+    required this.foodNumber,
+    required this.foodName,
+    this.foodNameKana,
+    this.foodGroup,
+    this.category,
+    this.energy,
+    this.water,
+    this.protein,
+    this.fat,
+    this.carbohydrate,
+    this.ash,
+    this.sodium,
+    this.potassium,
+    this.calcium,
+    this.magnesium,
+    this.phosphorus,
+    this.iron,
+    this.zinc,
+    this.copper,
+    this.manganese,
+    this.iodine,
+    this.selenium,
+    this.chromium,
+    this.molybdenum,
+    this.retinol,
+    this.alphaCarotene,
+    this.betaCarotene,
+    this.betaCryptoxanthin,
+    this.betaCaroteneEquivalent,
+    this.retinolActivityEquivalent,
+    this.vitaminD,
+    this.alphaTocopherol,
+    this.betaTocopherol,
+    this.gammaTocopherol,
+    this.deltaTocopherol,
+    this.vitaminK,
+    this.vitaminB1,
+    this.vitaminB2,
+    this.niacin,
+    this.vitaminB6,
+    this.vitaminB12,
+    this.folate,
+    this.pantothenicAcid,
+    this.biotin,
+    this.vitaminC,
+    this.saltEquivalent,
+    this.saturatedFat,
+    this.monounsaturatedFat,
+    this.polyunsaturatedFat,
+    this.cholesterol,
+    this.dietaryFiber,
+    this.solubleFiber,
+    this.insolubleFiber,
+    this.organicAcid,
+    this.wasteRate,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  /// 基本栄養素（カロリー、タンパク質、脂質、炭水化物）の取得
+  Map<String, double> getBasicNutrition() {
+    return {
+      'energy': energy ?? 0.0,
+      'protein': protein ?? 0.0,
+      'fat': fat ?? 0.0,
+      'carbohydrate': carbohydrate ?? 0.0,
+    };
+  }
+
+  /// ミネラル情報の取得
+  Map<String, double> getMinerals() {
+    return {
+      'sodium': sodium ?? 0.0,
+      'potassium': potassium ?? 0.0,
+      'calcium': calcium ?? 0.0,
+      'magnesium': magnesium ?? 0.0,
+      'phosphorus': phosphorus ?? 0.0,
+      'iron': iron ?? 0.0,
+      'zinc': zinc ?? 0.0,
+    };
+  }
+
+  /// ビタミン情報の取得
+  Map<String, double> getVitamins() {
+    return {
+      'vitaminA': retinolActivityEquivalent ?? 0.0,
+      'vitaminD': vitaminD ?? 0.0,
+      'vitaminB1': vitaminB1 ?? 0.0,
+      'vitaminB2': vitaminB2 ?? 0.0,
+      'vitaminB6': vitaminB6 ?? 0.0,
+      'vitaminB12': vitaminB12 ?? 0.0,
+      'vitaminC': vitaminC ?? 0.0,
+      'folate': folate ?? 0.0,
+    };
+  }
+}

--- a/lib/data/seeds/basic_food_mapping_seed.dart
+++ b/lib/data/seeds/basic_food_mapping_seed.dart
@@ -1,0 +1,314 @@
+/// 基本的な食品マッピングデータ（日本の一般的な食材）
+/// 
+/// 注意: これは実装例であり、実際の運用では文部科学省の
+/// 日本食品標準成分表から正確なデータを取得する必要があります
+
+class BasicFoodMappingSeed {
+  /// 基本的な食品マッピングデータ
+  static const List<Map<String, dynamic>> basicMappings = [
+    // 野菜類
+    {
+      'ingredientName': '玉ねぎ',
+      'aliases': 'たまねぎ,タマネギ,onion',
+      'category': '野菜',
+      'unitConversionFactor': 200.0, // 1個 = 200g
+      'unit': '個',
+      'ediblePortion': 0.95, // 廃棄率5%
+      'nutritionData': {
+        'foodNumber': '06001',
+        'foodName': 'たまねぎ 鱗茎 生',
+        'energy': 37.0,
+        'protein': 1.0,
+        'fat': 0.1,
+        'carbohydrate': 8.8,
+        'sodium': 2.0,
+        'potassium': 150.0,
+        'calcium': 21.0,
+        'dietaryFiber': 1.6,
+      }
+    },
+    {
+      'ingredientName': 'なす',
+      'aliases': 'ナス,茄子,eggplant',
+      'category': '野菜',
+      'unitConversionFactor': 80.0, // 1本 = 80g
+      'unit': '本',
+      'ediblePortion': 0.95,
+      'nutritionData': {
+        'foodNumber': '06014',
+        'foodName': 'なす 果実 生',
+        'energy': 22.0,
+        'protein': 1.1,
+        'fat': 0.1,
+        'carbohydrate': 5.1,
+        'sodium': 1.0,
+        'potassium': 220.0,
+        'calcium': 18.0,
+        'dietaryFiber': 2.2,
+      }
+    },
+    {
+      'ingredientName': 'ピーマン',
+      'aliases': 'green pepper',
+      'category': '野菜',
+      'unitConversionFactor': 30.0, // 1個 = 30g
+      'unit': '個',
+      'ediblePortion': 0.85, // 種と軸を除く
+      'nutritionData': {
+        'foodNumber': '06024',
+        'foodName': 'ピーマン 果実 生',
+        'energy': 22.0,
+        'protein': 0.9,
+        'fat': 0.2,
+        'carbohydrate': 5.1,
+        'sodium': 1.0,
+        'potassium': 190.0,
+        'calcium': 11.0,
+        'vitaminC': 76.0,
+        'dietaryFiber': 2.3,
+      }
+    },
+    {
+      'ingredientName': 'さやいんげん',
+      'aliases': 'いんげん,インゲン,green beans',
+      'category': '野菜',
+      'unitConversionFactor': 8.0, // 1本 = 8g
+      'unit': '本',
+      'ediblePortion': 0.90,
+      'nutritionData': {
+        'foodNumber': '06015',
+        'foodName': 'いんげんまめ さやいんげん 若ざや 生',
+        'energy': 23.0,
+        'protein': 1.8,
+        'fat': 0.1,
+        'carbohydrate': 4.6,
+        'sodium': 1.0,
+        'potassium': 260.0,
+        'calcium': 40.0,
+        'dietaryFiber': 2.4,
+      }
+    },
+
+    // 肉類
+    {
+      'ingredientName': '豚肉',
+      'aliases': '豚,ぶた肉,pork',
+      'category': '肉類',
+      'unitConversionFactor': 100.0, // 1枚 = 100g（目安）
+      'unit': '枚',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '11005',
+        'foodName': 'ぶた 肩ロース 脂身つき 生',
+        'energy': 253.0,
+        'protein': 17.1,
+        'fat': 19.2,
+        'carbohydrate': 0.2,
+        'sodium': 54.0,
+        'potassium': 300.0,
+        'iron': 0.6,
+      }
+    },
+    {
+      'ingredientName': '豚しゃぶ肉',
+      'aliases': '豚薄切り肉,豚バラ薄切り',
+      'category': '肉類',
+      'unitConversionFactor': 100.0,
+      'unit': 'g',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '11007',
+        'foodName': 'ぶた ばら 脂身つき 生',
+        'energy': 386.0,
+        'protein': 14.2,
+        'fat': 34.6,
+        'carbohydrate': 0.1,
+        'sodium': 48.0,
+        'potassium': 240.0,
+        'iron': 0.6,
+      }
+    },
+    {
+      'ingredientName': '鶏もも肉',
+      'aliases': '鶏肉,とり肉,chicken thigh',
+      'category': '肉類',
+      'unitConversionFactor': 250.0, // 1枚 = 250g
+      'unit': '枚',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '11015',
+        'foodName': 'にわとり もも 皮つき 生',
+        'energy': 200.0,
+        'protein': 16.2,
+        'fat': 14.0,
+        'carbohydrate': 0.0,
+        'sodium': 98.0,
+        'potassium': 270.0,
+        'iron': 0.6,
+      }
+    },
+
+    // 調味料類
+    {
+      'ingredientName': '醤油',
+      'aliases': 'しょうゆ,しょう油,soy sauce',
+      'category': '調味料',
+      'unitConversionFactor': 15.0, // 大さじ1 = 15ml
+      'unit': '大さじ',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '18001',
+        'foodName': 'しょうゆ 濃口',
+        'energy': 71.0,
+        'protein': 7.7,
+        'fat': 0.0,
+        'carbohydrate': 10.1,
+        'sodium': 5700.0,
+        'potassium': 610.0,
+      }
+    },
+    {
+      'ingredientName': 'みりん',
+      'aliases': 'mirin',
+      'category': '調味料',
+      'unitConversionFactor': 15.0, // 大さじ1 = 15ml
+      'unit': '大さじ',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '18011',
+        'foodName': 'みりん 本みりん',
+        'energy': 241.0,
+        'protein': 0.1,
+        'fat': 0.0,
+        'carbohydrate': 43.2,
+        'sodium': 11.0,
+        'potassium': 5.0,
+      }
+    },
+    {
+      'ingredientName': 'ごま油',
+      'aliases': 'sesame oil',
+      'category': '調味料',
+      'unitConversionFactor': 5.0, // 小さじ1 = 5ml
+      'unit': '小さじ',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '17024',
+        'foodName': 'ごま油',
+        'energy': 921.0,
+        'protein': 0.0,
+        'fat': 100.0,
+        'carbohydrate': 0.0,
+        'sodium': 0.0,
+        'vitaminE': 0.1,
+      }
+    },
+
+    // 主食類
+    {
+      'ingredientName': 'そうめん',
+      'aliases': '素麺,そーめん,somen',
+      'category': '主食',
+      'unitConversionFactor': 50.0, // 1束 = 50g
+      'unit': '束',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '01020',
+        'foodName': 'そうめん・ひやむぎ 乾',
+        'energy': 356.0,
+        'protein': 9.5,
+        'fat': 1.1,
+        'carbohydrate': 72.7,
+        'sodium': 1800.0,
+        'potassium': 120.0,
+      }
+    },
+
+    // その他
+    {
+      'ingredientName': 'だし汁',
+      'aliases': 'だし,出汁,dashi',
+      'category': 'その他',
+      'unitConversionFactor': 1.0, // 1ml = 1g
+      'unit': 'ml',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '19001',
+        'foodName': 'かつおだし',
+        'energy': 3.0,
+        'protein': 0.8,
+        'fat': 0.0,
+        'carbohydrate': 0.1,
+        'sodium': 270.0,
+        'potassium': 88.0,
+      }
+    },
+    {
+      'ingredientName': 'ちりめんじゃこ',
+      'aliases': 'しらす干し,じゃこ',
+      'category': '魚介類',
+      'unitConversionFactor': 15.0, // 大さじ1 = 15g
+      'unit': '大さじ',
+      'ediblePortion': 1.0,
+      'nutritionData': {
+        'foodNumber': '10042',
+        'foodName': 'しらす干し 半乾燥品',
+        'energy': 206.0,
+        'protein': 40.5,
+        'fat': 3.6,
+        'carbohydrate': 0.5,
+        'sodium': 1100.0,
+        'calcium': 520.0,
+      }
+    },
+  ];
+
+  /// シード実行のためのSQL生成（参考）
+  static String generateInsertSQL() {
+    final buffer = StringBuffer();
+    
+    buffer.writeln('-- 基本的な食品マッピングデータ');
+    buffer.writeln('-- 注意: 実際の数値は文部科学省の公式データを使用してください\n');
+    
+    for (int i = 0; i < basicMappings.length; i++) {
+      final mapping = basicMappings[i];
+      final nutrition = mapping['nutritionData'] as Map<String, dynamic>;
+      
+      // 栄養データテーブルへの挿入
+      buffer.writeln('INSERT INTO nutrition_data_table (');
+      buffer.writeln('  food_number, food_name, energy, protein, fat, carbohydrate,');
+      buffer.writeln('  sodium, potassium, calcium, dietary_fiber, vitamin_c, iron');
+      buffer.writeln(') VALUES (');
+      buffer.writeln("  '${nutrition['foodNumber']}',");
+      buffer.writeln("  '${nutrition['foodName']}',");
+      buffer.writeln("  ${nutrition['energy']},");
+      buffer.writeln("  ${nutrition['protein']},");
+      buffer.writeln("  ${nutrition['fat']},");
+      buffer.writeln("  ${nutrition['carbohydrate']},");
+      buffer.writeln("  ${nutrition['sodium']},");
+      buffer.writeln("  ${nutrition['potassium'] ?? 0},");
+      buffer.writeln("  ${nutrition['calcium'] ?? 0},");
+      buffer.writeln("  ${nutrition['dietaryFiber'] ?? 0},");
+      buffer.writeln("  ${nutrition['vitaminC'] ?? 0},");
+      buffer.writeln("  ${nutrition['iron'] ?? 0}");
+      buffer.writeln(');\n');
+      
+      // 食品マッピングテーブルへの挿入
+      buffer.writeln('INSERT INTO food_mapping_table (');
+      buffer.writeln('  ingredient_name, nutrition_data_id, confidence,');
+      buffer.writeln('  unit_conversion_factor, unit, aliases, category, edible_portion');
+      buffer.writeln(') VALUES (');
+      buffer.writeln("  '${mapping['ingredientName']}',");
+      buffer.writeln("  (SELECT id FROM nutrition_data_table WHERE food_number = '${nutrition['foodNumber']}'),");
+      buffer.writeln("  0.9,");
+      buffer.writeln("  ${mapping['unitConversionFactor']},");
+      buffer.writeln("  '${mapping['unit']}',");
+      buffer.writeln("  '${mapping['aliases']}',");
+      buffer.writeln("  '${mapping['category']}',");
+      buffer.writeln("  ${mapping['ediblePortion']}");
+      buffer.writeln(');\n');
+    }
+    
+    return buffer.toString();
+  }
+}

--- a/lib/presentation/pages/recipe_edit_page.dart
+++ b/lib/presentation/pages/recipe_edit_page.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -7,7 +8,60 @@ import '../../core/themes/app_colors.dart';
 import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../../data/datasources/app_database.dart';
+import '../../core/services/recipe_nutrition_analysis_service.dart';
+import '../../core/services/ogp_fetcher_service.dart';
+import '../../core/services/ingredient_extraction_service.dart';
+import '../../data/models/japanese_food_composition_table.dart';
 import '../providers/database_provider.dart';
+
+/// 材料アイテム（UI用）
+class IngredientItem {
+  final String name;
+  final double? amount;
+  final String? unit;
+  final String originalText;
+  final bool isAnalyzed;
+  final double? calories;
+  final double? protein;
+  final double? fat;
+  final double? carbohydrate;
+
+  IngredientItem({
+    required this.name,
+    this.amount,
+    this.unit,
+    required this.originalText,
+    this.isAnalyzed = false,
+    this.calories,
+    this.protein,
+    this.fat,
+    this.carbohydrate,
+  });
+
+  IngredientItem copyWith({
+    String? name,
+    double? amount,
+    String? unit,
+    String? originalText,
+    bool? isAnalyzed,
+    double? calories,
+    double? protein,
+    double? fat,
+    double? carbohydrate,
+  }) {
+    return IngredientItem(
+      name: name ?? this.name,
+      amount: amount ?? this.amount,
+      unit: unit ?? this.unit,
+      originalText: originalText ?? this.originalText,
+      isAnalyzed: isAnalyzed ?? this.isAnalyzed,
+      calories: calories ?? this.calories,
+      protein: protein ?? this.protein,
+      fat: fat ?? this.fat,
+      carbohydrate: carbohydrate ?? this.carbohydrate,
+    );
+  }
+}
 
 /// レシピ編集ページ
 class RecipeEditPage extends ConsumerStatefulWidget {
@@ -28,6 +82,16 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
   late TextEditingController _titleController;
   late TextEditingController _tagsController;
   late TextEditingController _memoController;
+  late TextEditingController _recipeTextController;
+  late TextEditingController _caloriesController;
+  late TextEditingController _proteinController;
+  late TextEditingController _fatController;
+  late TextEditingController _carbohydrateController;
+  late TextEditingController _saltController;
+  late TextEditingController _fiberController;
+  late TextEditingController _vitaminCController;
+  
+  List<IngredientItem> _ingredientsList = [];
 
   @override
   void initState() {
@@ -35,6 +99,27 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
     _titleController = TextEditingController(text: widget.recipe.title);
     _tagsController = TextEditingController(text: widget.recipe.tags ?? '');
     _memoController = TextEditingController(text: widget.recipe.memo ?? '');
+    _recipeTextController = TextEditingController(text: widget.recipe.ingredientsRawText ?? '');
+    _caloriesController = TextEditingController(text: widget.recipe.calories?.toStringAsFixed(0) ?? '');
+    _proteinController = TextEditingController(text: widget.recipe.protein?.toStringAsFixed(1) ?? '');
+    _fatController = TextEditingController(text: widget.recipe.fat?.toStringAsFixed(1) ?? '');
+    _carbohydrateController = TextEditingController(text: widget.recipe.carbohydrate?.toStringAsFixed(1) ?? '');
+    _saltController = TextEditingController(text: widget.recipe.salt?.toStringAsFixed(2) ?? '');
+    _fiberController = TextEditingController(text: widget.recipe.fiber?.toStringAsFixed(1) ?? '');
+    _vitaminCController = TextEditingController(text: widget.recipe.vitaminC?.toStringAsFixed(0) ?? '');
+    
+    // 初期材料リストを構築
+    _initializeIngredientsList();
+  }
+  
+  void _initializeIngredientsList() {
+    // 保存されている材料JSONから復元
+    if (widget.recipe.ingredientsJson != null && widget.recipe.ingredientsJson!.isNotEmpty) {
+      _ingredientsList = _ingredientsListFromJson(widget.recipe.ingredientsJson);
+    } else {
+      // 空のリストから開始
+      _ingredientsList = [];
+    }
   }
 
   @override
@@ -117,12 +202,24 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
                 _buildTitleField(),
                 SizedBox(height: AppConstants.paddingM.h),
                 
-                // タグ入力
-                _buildTagsField(),
-                SizedBox(height: AppConstants.paddingM.h),
+                // タグ入力（一時的に非表示）
+                // _buildTagsField(),
+                // SizedBox(height: AppConstants.paddingM.h),
                 
                 // メモ入力
                 _buildMemoField(),
+                SizedBox(height: AppConstants.paddingL.h),
+                
+                // レシピ本文表示
+                _buildRecipeTextField(),
+                SizedBox(height: AppConstants.paddingL.h),
+                
+                // 材料リスト
+                _buildIngredientsListSection(),
+                SizedBox(height: AppConstants.paddingL.h),
+                
+                // 栄養情報入力セクション
+                _buildNutritionInputSection(),
                 SizedBox(height: AppConstants.paddingL.h),
               ],
             ),
@@ -310,16 +407,998 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
     );
   }
 
+  Widget _buildRecipeTextField() {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+        border: Border.all(color: AppColors.textDisabled),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ヘッダー部分
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              AppConstants.paddingM.w,
+              AppConstants.paddingM.h,
+              AppConstants.paddingS.w,
+              AppConstants.paddingS.h,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'レシピ本文',
+                  style: AppTextStyles.headline3,
+                ),
+                // URLから再取得ボタン（右端に配置）
+                ElevatedButton.icon(
+                  onPressed: _reanalyzeFromUrl,
+                  icon: Icon(Icons.refresh, size: 16.w),
+                  label: const Text('再取得'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
+                    padding: EdgeInsets.symmetric(
+                      horizontal: AppConstants.paddingS.w,
+                      vertical: AppConstants.paddingS.h,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          
+          // テキストフィールド
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              AppConstants.paddingM.w,
+              0,
+              AppConstants.paddingM.w,
+              AppConstants.paddingM.h,
+            ),
+            child: TextFormField(
+              controller: _recipeTextController,
+              decoration: InputDecoration(
+                hintText: 'レシピの材料や作り方など',
+                prefixIcon: Icon(Icons.description, size: 20.w),
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIngredientsListSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              '材料リスト',
+              style: AppTextStyles.headline3,
+            ),
+            Spacer(),
+            TextButton.icon(
+              onPressed: _analyzeIngredientsFromText,
+              icon: Icon(Icons.analytics, size: 16.w),
+              label: const Text('分析'),
+              style: TextButton.styleFrom(
+                foregroundColor: AppColors.secondary,
+              ),
+            ),
+            TextButton.icon(
+              onPressed: _addIngredientManually,
+              icon: Icon(Icons.add, size: 18.w),
+              label: const Text('追加'),
+              style: TextButton.styleFrom(
+                foregroundColor: AppColors.primary,
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: AppConstants.paddingS.h),
+        
+        if (_ingredientsList.isEmpty) ...[
+          Container(
+            padding: EdgeInsets.all(AppConstants.paddingL.w),
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+              border: Border.all(color: AppColors.textDisabled),
+            ),
+            child: Column(
+              children: [
+                Icon(
+                  Icons.shopping_basket_outlined,
+                  size: 48.w,
+                  color: AppColors.textSecondary,
+                ),
+                SizedBox(height: AppConstants.paddingS.h),
+                Text(
+                  '材料が登録されていません',
+                  style: AppTextStyles.body2.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+                SizedBox(height: AppConstants.paddingS.h),
+                Text(
+                  'レシピ本文から材料を分析するか、手動で追加してください',
+                  style: AppTextStyles.caption.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ] else ...[
+          ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: _ingredientsList.length,
+            separatorBuilder: (context, index) => SizedBox(height: AppConstants.paddingS.h),
+            itemBuilder: (context, index) {
+              return _buildIngredientCard(_ingredientsList[index], index);
+            },
+          ),
+        ],
+        
+      ],
+    );
+  }
+
+  Widget _buildIngredientCard(IngredientItem ingredient, int index) {
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingM.w),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+        border: Border.all(
+          color: ingredient.isAnalyzed 
+              ? AppColors.success.withOpacity(0.3)
+              : AppColors.textDisabled,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      ingredient.name,
+                      style: AppTextStyles.body1.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (ingredient.amount != null) ...[
+                      SizedBox(height: 2.h),
+                      Text(
+                        '${ingredient.amount}${ingredient.unit ?? ''}',
+                        style: AppTextStyles.body2.copyWith(
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              Row(
+                children: [
+                  if (ingredient.isAnalyzed)
+                    Icon(
+                      Icons.check_circle,
+                      size: 20.w,
+                      color: AppColors.success,
+                    )
+                  else
+                    Icon(
+                      Icons.help_outline,
+                      size: 20.w,
+                      color: AppColors.warning,
+                    ),
+                  SizedBox(width: AppConstants.paddingS.w),
+                  PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'edit') {
+                        _editIngredient(index);
+                      } else if (value == 'delete') {
+                        _deleteIngredient(index);
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: 'edit',
+                        child: Text('編集'),
+                      ),
+                      const PopupMenuItem(
+                        value: 'delete',
+                        child: Text('削除'),
+                      ),
+                    ],
+                    child: Icon(
+                      Icons.more_vert,
+                      size: 20.w,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          
+          if (ingredient.isAnalyzed) ...[
+            SizedBox(height: AppConstants.paddingS.h),
+            Container(
+              padding: EdgeInsets.all(AppConstants.paddingS.w),
+              decoration: BoxDecoration(
+                color: AppColors.success.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _buildNutritionValue(
+                      '${(ingredient.calories ?? 0).toStringAsFixed(0)} kcal',
+                      Icons.local_fire_department,
+                      AppColors.error,
+                    ),
+                  ),
+                  Expanded(
+                    child: _buildNutritionValue(
+                      '${(ingredient.protein ?? 0).toStringAsFixed(1)}g',
+                      Icons.fitness_center,
+                      AppColors.primary,
+                    ),
+                  ),
+                  Expanded(
+                    child: _buildNutritionValue(
+                      '${(ingredient.fat ?? 0).toStringAsFixed(1)}g',
+                      Icons.water_drop,
+                      AppColors.warning,
+                    ),
+                  ),
+                  Expanded(
+                    child: _buildNutritionValue(
+                      '${(ingredient.carbohydrate ?? 0).toStringAsFixed(1)}g',
+                      Icons.grain,
+                      AppColors.success,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNutritionValue(String value, IconData icon, Color color) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          icon,
+          size: 16.w,
+          color: color,
+        ),
+        SizedBox(width: 4.w),
+        Text(
+          value,
+          style: AppTextStyles.caption.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildNutritionInputSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '栄養情報（1人前あたり）',
+          style: AppTextStyles.headline3,
+        ),
+        SizedBox(height: AppConstants.paddingS.h),
+        
+        // 基本栄養素入力
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: _caloriesController,
+                decoration: InputDecoration(
+                  labelText: 'エネルギー',
+                  hintText: '200',
+                  suffixText: 'kcal',
+                  prefixIcon: Icon(Icons.local_fire_department, size: 20.w),
+                ),
+                keyboardType: TextInputType.number,
+              ),
+            ),
+            SizedBox(width: AppConstants.paddingS.w),
+            Expanded(
+              child: TextFormField(
+                controller: _proteinController,
+                decoration: InputDecoration(
+                  labelText: 'タンパク質',
+                  hintText: '15.5',
+                  suffixText: 'g',
+                  prefixIcon: Icon(Icons.fitness_center, size: 20.w),
+                ),
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: AppConstants.paddingM.h),
+        
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: _fatController,
+                decoration: InputDecoration(
+                  labelText: '脂質',
+                  hintText: '8.2',
+                  suffixText: 'g',
+                  prefixIcon: Icon(Icons.water_drop, size: 20.w),
+                ),
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              ),
+            ),
+            SizedBox(width: AppConstants.paddingS.w),
+            Expanded(
+              child: TextFormField(
+                controller: _carbohydrateController,
+                decoration: InputDecoration(
+                  labelText: '炭水化物',
+                  hintText: '25.3',
+                  suffixText: 'g',
+                  prefixIcon: Icon(Icons.grain, size: 20.w),
+                ),
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: AppConstants.paddingM.h),
+        
+        // その他の栄養素入力
+        ExpansionTile(
+          title: Text(
+            'その他の栄養素',
+            style: AppTextStyles.body1,
+          ),
+          children: [
+            Padding(
+              padding: EdgeInsets.all(AppConstants.paddingS.w),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: _saltController,
+                          decoration: InputDecoration(
+                            labelText: '食塩相当量',
+                            hintText: '1.2',
+                            suffixText: 'g',
+                            prefixIcon: Icon(Icons.grain, size: 20.w),
+                          ),
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                        ),
+                      ),
+                      SizedBox(width: AppConstants.paddingS.w),
+                      Expanded(
+                        child: TextFormField(
+                          controller: _fiberController,
+                          decoration: InputDecoration(
+                            labelText: '食物繊維',
+                            hintText: '2.1',
+                            suffixText: 'g',
+                            prefixIcon: Icon(Icons.eco, size: 20.w),
+                          ),
+                          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: AppConstants.paddingM.h),
+                  TextFormField(
+                    controller: _vitaminCController,
+                    decoration: InputDecoration(
+                      labelText: 'ビタミンC',
+                      hintText: '15',
+                      suffixText: 'mg',
+                      prefixIcon: Icon(Icons.local_hospital, size: 20.w),
+                    ),
+                    keyboardType: TextInputType.number,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        
+        // 自動抽出フラグの表示
+        if (widget.recipe.isNutritionAutoExtracted == true) ...[
+          SizedBox(height: AppConstants.paddingS.h),
+          Row(
+            children: [
+              Icon(
+                Icons.auto_awesome,
+                size: 16.w,
+                color: AppColors.primary,
+              ),
+              SizedBox(width: 4.w),
+              Text(
+                '自動分析済み（手動で編集可能）',
+                style: AppTextStyles.caption.copyWith(
+                  color: AppColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildNutritionCards() {
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingM.w),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+        border: Border.all(color: AppColors.textDisabled),
+      ),
+      child: Column(
+        children: [
+          // 基本栄養素
+          Row(
+            children: [
+              Expanded(
+                child: _buildNutritionItem(
+                  'エネルギー',
+                  '${(widget.recipe.calories ?? 0).toStringAsFixed(0)} kcal',
+                  Icons.local_fire_department,
+                  AppColors.error,
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingS.w),
+              Expanded(
+                child: _buildNutritionItem(
+                  'タンパク質',
+                  '${(widget.recipe.protein ?? 0).toStringAsFixed(1)} g',
+                  Icons.fitness_center,
+                  AppColors.primary,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: AppConstants.paddingS.h),
+          Row(
+            children: [
+              Expanded(
+                child: _buildNutritionItem(
+                  '脂質',
+                  '${(widget.recipe.fat ?? 0).toStringAsFixed(1)} g',
+                  Icons.water_drop,
+                  AppColors.warning,
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingS.w),
+              Expanded(
+                child: _buildNutritionItem(
+                  '炭水化物',
+                  '${(widget.recipe.carbohydrate ?? 0).toStringAsFixed(1)} g',
+                  Icons.grain,
+                  AppColors.success,
+                ),
+              ),
+            ],
+          ),
+          
+          
+          // 人前あたりの表示
+          SizedBox(height: AppConstants.paddingS.h),
+          Text(
+            '1人前あたりの栄養価',
+            style: AppTextStyles.caption.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+          if (false && (widget.recipe.servings ?? 1) > 1) ...[
+            SizedBox(height: AppConstants.paddingS.h),
+            Text(
+              '${widget.recipe.servings}人前の栄養価',
+              style: AppTextStyles.caption.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNutritionItem(String label, String value, IconData icon, Color color) {
+    return Column(
+      children: [
+        Icon(
+          icon,
+          size: 24.w,
+          color: color,
+        ),
+        SizedBox(height: 4.h),
+        Text(
+          label,
+          style: AppTextStyles.caption.copyWith(
+            color: AppColors.textSecondary,
+          ),
+        ),
+        SizedBox(height: 2.h),
+        Text(
+          value,
+          style: AppTextStyles.body1.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 材料を手動で追加
+  void _addIngredientManually() {
+    showDialog(
+      context: context,
+      builder: (context) => _buildAddIngredientDialog(),
+    );
+  }
+
+  /// 材料を編集
+  void _editIngredient(int index) {
+    showDialog(
+      context: context,
+      builder: (context) => _buildEditIngredientDialog(_ingredientsList[index], index),
+    );
+  }
+
+  /// 材料を削除
+  void _deleteIngredient(int index) {
+    setState(() {
+      _ingredientsList.removeAt(index);
+    });
+  }
+
+  /// レシピ本文から材料を分析
+  Future<void> _analyzeIngredientsFromText() async {
+    final recipeText = _recipeTextController.text.trim();
+    
+    if (recipeText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('レシピ本文を入力してください'),
+          backgroundColor: AppColors.error,
+        ),
+      );
+      return;
+    }
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation(AppColors.primary),
+            ),
+            SizedBox(height: AppConstants.paddingM.h),
+            Text(
+              '材料を分析中...',
+              style: AppTextStyles.body2,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      final database = ref.read(databaseProvider);
+      final nutritionService = RecipeNutritionAnalysisService(database);
+      final result = await nutritionService.analyzeRecipe(recipeText);
+      
+      setState(() {
+        _ingredientsList = result.matchResults.map((matchResult) => IngredientItem(
+          name: matchResult.ingredient.name,
+          amount: matchResult.ingredient.amount,
+          unit: matchResult.ingredient.unit,
+          originalText: matchResult.ingredient.originalText,
+          isAnalyzed: matchResult.matchedFood != null,
+          calories: matchResult.matchedFood != null 
+              ? _calculateIndividualNutrition(matchResult.ingredient, matchResult.matchedFood!, 'calories')
+              : null,
+          protein: matchResult.matchedFood != null 
+              ? _calculateIndividualNutrition(matchResult.ingredient, matchResult.matchedFood!, 'protein')
+              : null,
+          fat: matchResult.matchedFood != null 
+              ? _calculateIndividualNutrition(matchResult.ingredient, matchResult.matchedFood!, 'fat')
+              : null,
+          carbohydrate: matchResult.matchedFood != null 
+              ? _calculateIndividualNutrition(matchResult.ingredient, matchResult.matchedFood!, 'carbohydrate')
+              : null,
+        )).toList();
+      });
+
+      Navigator.pop(context);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${result.ingredients.length}件の材料を抽出しました'),
+          backgroundColor: AppColors.success,
+        ),
+      );
+    } catch (e) {
+      Navigator.pop(context);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('材料の分析に失敗しました: $e'),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
+  /// 材料追加ダイアログ
+  Widget _buildAddIngredientDialog() {
+    final nameController = TextEditingController();
+    final amountController = TextEditingController();
+    final unitController = TextEditingController();
+
+    return AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: Text('材料を追加', style: AppTextStyles.headline3),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextFormField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              labelText: '材料名',
+              hintText: 'にんじん',
+            ),
+          ),
+          SizedBox(height: AppConstants.paddingM.h),
+          Row(
+            children: [
+              Expanded(
+                flex: 2,
+                child: TextFormField(
+                  controller: amountController,
+                  decoration: const InputDecoration(
+                    labelText: '分量',
+                    hintText: '100',
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingS.w),
+              Expanded(
+                child: TextFormField(
+                  controller: unitController,
+                  decoration: const InputDecoration(
+                    labelText: '単位',
+                    hintText: 'g',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text('キャンセル', style: AppTextStyles.body2),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            if (nameController.text.isNotEmpty) {
+              final newIngredient = IngredientItem(
+                name: nameController.text.trim(),
+                amount: double.tryParse(amountController.text),
+                unit: unitController.text.isNotEmpty ? unitController.text.trim() : null,
+                originalText: '${nameController.text} ${amountController.text} ${unitController.text}',
+                isAnalyzed: false,
+              );
+              
+              setState(() {
+                _ingredientsList.add(newIngredient);
+              });
+              
+              Navigator.pop(context);
+            }
+          },
+          child: const Text('追加'),
+        ),
+      ],
+    );
+  }
+
+  /// 材料編集ダイアログ
+  Widget _buildEditIngredientDialog(IngredientItem ingredient, int index) {
+    final nameController = TextEditingController(text: ingredient.name);
+    final amountController = TextEditingController(text: ingredient.amount?.toString() ?? '');
+    final unitController = TextEditingController(text: ingredient.unit ?? '');
+
+    return AlertDialog(
+      backgroundColor: AppColors.surface,
+      title: Text('材料を編集', style: AppTextStyles.headline3),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextFormField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              labelText: '材料名',
+            ),
+          ),
+          SizedBox(height: AppConstants.paddingM.h),
+          Row(
+            children: [
+              Expanded(
+                flex: 2,
+                child: TextFormField(
+                  controller: amountController,
+                  decoration: const InputDecoration(
+                    labelText: '分量',
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingS.w),
+              Expanded(
+                child: TextFormField(
+                  controller: unitController,
+                  decoration: const InputDecoration(
+                    labelText: '単位',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text('キャンセル', style: AppTextStyles.body2),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            if (nameController.text.isNotEmpty) {
+              final updatedIngredient = ingredient.copyWith(
+                name: nameController.text.trim(),
+                amount: double.tryParse(amountController.text),
+                unit: unitController.text.isNotEmpty ? unitController.text.trim() : null,
+                originalText: '${nameController.text} ${amountController.text} ${unitController.text}',
+              );
+              
+              setState(() {
+                _ingredientsList[index] = updatedIngredient;
+              });
+              
+              Navigator.pop(context);
+            }
+          },
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+
+  /// URLから材料を再取得
+  Future<void> _reanalyzeFromUrl() async {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation(AppColors.primary),
+            ),
+            SizedBox(height: AppConstants.paddingM.h),
+            Text(
+              'レシピ情報を再取得中...',
+              style: AppTextStyles.body2,
+            ),
+          ],
+        ),
+      ),
+    );
+    
+    try {
+      final ogpFetcher = OgpFetcherService();
+      final ogpData = await ogpFetcher.fetchOgpData(widget.recipe.url);
+      
+      if (ogpData.recipeText != null && ogpData.recipeText!.isNotEmpty) {
+        // レシピ本文を更新
+        setState(() {
+          _recipeTextController.text = ogpData.recipeText!;
+        });
+        
+        // 材料を抽出
+        final extractionService = IngredientExtractionService();
+        final ingredients = extractionService.extractIngredients(ogpData.recipeText!);
+        
+        // 栄養分析も実行
+        final database = ref.read(databaseProvider);
+        final nutritionService = RecipeNutritionAnalysisService(database);
+        final result = await nutritionService.analyzeRecipe(ogpData.recipeText!);
+        
+        // 材料リストと栄養情報を更新
+        setState(() {
+          _ingredientsList = ingredients.map((ingredient) => IngredientItem(
+            name: ingredient.name,
+            amount: ingredient.amount,
+            unit: ingredient.unit,
+            originalText: ingredient.originalText,
+            isAnalyzed: false, // 個別分析はまだ未実装
+          )).toList();
+          
+          _caloriesController.text = result.nutrition.energy.toStringAsFixed(0);
+          _proteinController.text = result.nutrition.protein.toStringAsFixed(1);
+          _fatController.text = result.nutrition.fat.toStringAsFixed(1);
+          _carbohydrateController.text = result.nutrition.carbohydrate.toStringAsFixed(1);
+          _saltController.text = result.nutrition.salt.toStringAsFixed(2);
+          _fiberController.text = result.nutrition.fiber.toStringAsFixed(1);
+          _vitaminCController.text = result.nutrition.vitaminC.toStringAsFixed(0);
+        });
+        
+        Navigator.pop(context);
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('レシピを再取得し、${ingredients.length}件の材料を抽出しました'),
+            backgroundColor: AppColors.success,
+          ),
+        );
+      } else {
+        Navigator.pop(context);
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('レシピ情報を取得できませんでした'),
+            backgroundColor: AppColors.warning,
+          ),
+        );
+      }
+    } catch (e) {
+      Navigator.pop(context);
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('再取得に失敗しました: $e'),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
+  /// 入力された材料から栄養分析
+  Future<void> _reanalyzeNutrition() async {
+    final recipeText = _recipeTextController.text.trim();
+        
+    if (recipeText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('材料テキストが入力されていません'),
+          backgroundColor: AppColors.error,
+        ),
+      );
+      return;
+    }
+    
+    // 栄養再分析の処理
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation(AppColors.primary),
+            ),
+            SizedBox(height: AppConstants.paddingM.h),
+            Text(
+              '栄養情報を分析中...',
+              style: AppTextStyles.body2,
+            ),
+          ],
+        ),
+      ),
+    );
+    
+    try {
+      final database = ref.read(databaseProvider);
+      final nutritionService = RecipeNutritionAnalysisService(database);
+      final result = await nutritionService.analyzeRecipe(recipeText);
+      
+      // 栄養情報を入力フィールドに反映
+      setState(() {
+        _caloriesController.text = result.nutrition.energy.toStringAsFixed(0);
+        _proteinController.text = result.nutrition.protein.toStringAsFixed(1);
+        _fatController.text = result.nutrition.fat.toStringAsFixed(1);
+        _carbohydrateController.text = result.nutrition.carbohydrate.toStringAsFixed(1);
+        _saltController.text = result.nutrition.salt.toStringAsFixed(2);
+        _fiberController.text = result.nutrition.fiber.toStringAsFixed(1);
+        _vitaminCController.text = result.nutrition.vitaminC.toStringAsFixed(0);
+      });
+      
+      Navigator.pop(context);
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('栄養分析を完了しました（${result.ingredients.length}件の材料を抽出）'),
+          backgroundColor: AppColors.success,
+        ),
+      );
+    } catch (e) {
+      Navigator.pop(context);
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('栄養分析に失敗しました: $e'),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
   Future<void> _saveChanges() async {
     if (!_formKey.currentState!.validate()) return;
 
     final recipeNotifier = ref.read(recipeRegistrationProvider.notifier);
+    
+    // 材料リストをJSONに変換
+    final ingredientsJson = _ingredientsListToJson();
     
     await recipeNotifier.updateExternalRecipe(
       recipeId: widget.recipe.id,
       title: _titleController.text,
       tags: _tagsController.text,
       memo: _memoController.text,
+      ingredientsRawText: _recipeTextController.text,
+      ingredientsJson: ingredientsJson,
+      calories: double.tryParse(_caloriesController.text),
+      protein: double.tryParse(_proteinController.text),
+      fat: double.tryParse(_fatController.text),
+      carbohydrate: double.tryParse(_carbohydrateController.text),
+      salt: double.tryParse(_saltController.text),
+      fiber: double.tryParse(_fiberController.text),
+      vitaminC: double.tryParse(_vitaminCController.text),
     );
     
     // 保存状態を監視
@@ -351,6 +1430,46 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
         );
       },
     );
+  }
+
+  /// 材料リストをJSONに変換
+  String _ingredientsListToJson() {
+    final ingredientsList = _ingredientsList.map((ingredient) => {
+      'name': ingredient.name,
+      'amount': ingredient.amount,
+      'unit': ingredient.unit,
+      'originalText': ingredient.originalText,
+      'isAnalyzed': ingredient.isAnalyzed,
+      'calories': ingredient.calories,
+      'protein': ingredient.protein,
+      'fat': ingredient.fat,
+      'carbohydrate': ingredient.carbohydrate,
+    }).toList();
+    
+    return json.encode(ingredientsList);
+  }
+
+  /// JSONから材料リストを復元
+  List<IngredientItem> _ingredientsListFromJson(String? jsonString) {
+    if (jsonString == null || jsonString.isEmpty) return [];
+    
+    try {
+      final jsonList = json.decode(jsonString) as List<dynamic>;
+      return jsonList.map((item) => IngredientItem(
+        name: item['name'] ?? '',
+        amount: item['amount']?.toDouble(),
+        unit: item['unit'],
+        originalText: item['originalText'] ?? '',
+        isAnalyzed: item['isAnalyzed'] ?? false,
+        calories: item['calories']?.toDouble(),
+        protein: item['protein']?.toDouble(),
+        fat: item['fat']?.toDouble(),
+        carbohydrate: item['carbohydrate']?.toDouble(),
+      )).toList();
+    } catch (e) {
+      print('材料JSONの解析に失敗: $e');
+      return [];
+    }
   }
 
   Future<void> _showDeleteConfirmation() async {
@@ -436,6 +1555,57 @@ class _RecipeEditPageState extends ConsumerState<RecipeEditPage> {
     _titleController.dispose();
     _tagsController.dispose();
     _memoController.dispose();
+    _recipeTextController.dispose();
+    _caloriesController.dispose();
+    _proteinController.dispose();
+    _fatController.dispose();
+    _carbohydrateController.dispose();
+    _saltController.dispose();
+    _fiberController.dispose();
+    _vitaminCController.dispose();
     super.dispose();
+  }
+
+  /// 個別材料の栄養価を計算
+  double? _calculateIndividualNutrition(Ingredient ingredient, JapaneseFoodCompositionTableData food, String nutrientType) {
+    if (ingredient.amount == null) return null;
+    
+    // 重量をグラムに変換
+    final grossWeight = _convertToGrams(ingredient.amount!, ingredient.unit);
+    final edibleWeight = grossWeight * (1 - (food.refuse ?? 0) / 100);
+    final multiplier = edibleWeight / 100; // 100gあたりの値から実際の量を計算
+    
+    switch (nutrientType) {
+      case 'calories':
+        return (food.enercKcal ?? 0) * multiplier;
+      case 'protein':
+        return (food.prot ?? 0) * multiplier;
+      case 'fat':
+        return (food.fat ?? 0) * multiplier;
+      case 'carbohydrate':
+        return (food.choavl ?? 0) * multiplier;
+      default:
+        return null;
+    }
+  }
+
+  /// 単位変換
+  double _convertToGrams(double amount, String? unit) {
+    final normalizedUnit = (unit ?? '').toLowerCase();
+    
+    final conversionMap = {
+      'g': 1.0,
+      'kg': 1000.0,
+      'ml': 1.0, // 液体は1ml=1gと仮定
+      '個': 100.0, // 野菜1個の平均重量
+      'コ': 100.0,
+      '本': 50.0,  // 野菜1本の平均重量
+      '枚': 100.0, // 肉1枚の平均重量
+      '束': 100.0,
+      '大さじ': 15.0,
+      '小さじ': 5.0,
+    };
+    
+    return amount * (conversionMap[normalizedUnit] ?? 1.0);
   }
 }

--- a/test_recipe_nutrition_analysis.dart
+++ b/test_recipe_nutrition_analysis.dart
@@ -1,0 +1,535 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'lib/core/services/ingredient_extraction_service.dart';
+import 'lib/data/models/japanese_food_composition_table.dart';
+
+/// 4つのレシピでの完全栄養分析テスト
+class RecipeNutritionAnalysisTest {
+  final IngredientExtractionService _extractor = IngredientExtractionService();
+  final Map<String, JapaneseFoodCompositionTableData> _foodDatabase = {};
+
+  /// テスト実行
+  Future<void> runTest() async {
+    print('=== レシピ栄養分析テスト開始 ===\n');
+    
+    // 1. 食品データベースの準備（サンプルデータのみ）
+    await _prepareFoodDatabase();
+    
+    // 2. テストレシピデータ
+    final testRecipes = [
+      {
+        'name': '白ごはん.com - 豚しゃぶ肉のぶっかけそうめん',
+        'ingredients': '''
+豚しゃぶ肉：100～150g
+なす：2本（大きめなら1本でも）
+そうめん：150g（50g×3束）
+刻みねぎ：少々
+おろし生姜：少々
+だし汁：175ml
+醤油：大さじ2と1/2
+みりん：大さじ2
+        ''',
+      },
+      {
+        'name': 'レタスクラブ - ピーマンとちりめんじゃこの梅あえ',
+        'ingredients': '''
+ちりめんじゃこ: 大さじ1
+ピーマン: 4個
+練り梅(チューブ): 小さじ1/2
+めんつゆ(3倍濃縮): 小さじ1
+ごま油: 大さじ1/2
+削りがつお: 適量
+        ''',
+      },
+      {
+        'name': 'オレンジページ - なすといんげんの南蛮漬け',
+        'ingredients': '''
+なす: 3個
+さやいんげん: 10本
+鶏もも肉: 1枚（約250g）
+しょうゆ: 小さじ1/2
+酒: 小さじ1/2
+赤唐辛子の小口切り: 1本分
+砂糖: 大さじ1
+だし汁: 大さじ4
+酢: 大さじ3
+しょうゆ: 大さじ2
+ごま油: 小さじ1/2
+揚げ油: 適宜
+        ''',
+      },
+      {
+        'name': 'みんなのきょうの料理 - 豚の梅照り焼き',
+        'ingredients': '''
+豚肩ロース肉（しょうが焼き用）: 6枚 (240g)
+たまねぎ: 1/2コ (100g)
+梅干し（塩分14%）: 2～3コ (35g)
+みりん: 大さじ2
+酒: 大さじ1
+砂糖: 小さじ1
+しょうゆ: 小さじ1/2
+キャベツ（せん切り）: 適量
+塩: 少々
+小麦粉: 適量
+米油（またはサラダ油）: 適量
+        ''',
+      },
+    ];
+
+    // 3. 各レシピを分析
+    for (int i = 0; i < testRecipes.length; i++) {
+      final recipe = testRecipes[i];
+      await _analyzeRecipe(i + 1, recipe);
+      print('');
+    }
+
+    print('=== テスト完了 ===');
+  }
+
+  /// 食品データベースの準備（サンプルデータ）
+  Future<void> _prepareFoodDatabase() async {
+    print('📊 食品データベースの準備中...');
+    
+    // 実際の日本食品標準成分表からサンプルデータを作成
+    // 本来はkatoharu432さんのJSONから全データを取得
+    final sampleData = [
+      // 豚肉類
+      {
+        'foodId': 11005,
+        'foodName': 'ぶた 肩ロース 脂身つき 生',
+        'enercKcal': 253.0,
+        'prot': 17.1,
+        'fat': 19.2,
+        'choavl': 0.2,
+        'na': 54.0,
+        'k': 300.0,
+        'ca': 5.0,
+        'fe': 0.6,
+        'fib': 0.0,
+        'vitC': 1.0,
+      },
+      {
+        'foodId': 11007,
+        'foodName': 'ぶた ばら 脂身つき 生',
+        'enercKcal': 386.0,
+        'prot': 14.2,
+        'fat': 34.6,
+        'choavl': 0.1,
+        'na': 48.0,
+        'k': 240.0,
+        'ca': 5.0,
+        'fe': 0.6,
+        'fib': 0.0,
+        'vitC': 1.0,
+      },
+      
+      // 鶏肉類
+      {
+        'foodId': 11015,
+        'foodName': 'にわとり もも 皮つき 生',
+        'enercKcal': 200.0,
+        'prot': 16.2,
+        'fat': 14.0,
+        'choavl': 0.0,
+        'na': 98.0,
+        'k': 270.0,
+        'ca': 6.0,
+        'fe': 0.6,
+        'fib': 0.0,
+        'vitC': 3.0,
+      },
+      
+      // 野菜類
+      {
+        'foodId': 6001,
+        'foodName': 'たまねぎ 鱗茎 生',
+        'enercKcal': 37.0,
+        'prot': 1.0,
+        'fat': 0.1,
+        'choavl': 8.8,
+        'na': 2.0,
+        'k': 150.0,
+        'ca': 21.0,
+        'fe': 0.2,
+        'fib': 1.6,
+        'vitC': 8.0,
+      },
+      {
+        'foodId': 6014,
+        'foodName': 'なす 果実 生',
+        'enercKcal': 22.0,
+        'prot': 1.1,
+        'fat': 0.1,
+        'choavl': 5.1,
+        'na': 1.0,
+        'k': 220.0,
+        'ca': 18.0,
+        'fe': 0.3,
+        'fib': 2.2,
+        'vitC': 5.0,
+      },
+      {
+        'foodId': 6024,
+        'foodName': 'ピーマン 果実 生',
+        'enercKcal': 22.0,
+        'prot': 0.9,
+        'fat': 0.2,
+        'choavl': 5.1,
+        'na': 1.0,
+        'k': 190.0,
+        'ca': 11.0,
+        'fe': 0.4,
+        'fib': 2.3,
+        'vitC': 76.0,
+      },
+      {
+        'foodId': 6015,
+        'foodName': 'いんげんまめ さやいんげん 若ざや 生',
+        'enercKcal': 23.0,
+        'prot': 1.8,
+        'fat': 0.1,
+        'choavl': 4.6,
+        'na': 1.0,
+        'k': 260.0,
+        'ca': 40.0,
+        'fe': 0.7,
+        'fib': 2.4,
+        'vitC': 8.0,
+      },
+      {
+        'foodId': 6029,
+        'foodName': 'キャベツ 結球葉 生',
+        'enercKcal': 23.0,
+        'prot': 1.3,
+        'fat': 0.2,
+        'choavl': 5.2,
+        'na': 5.0,
+        'k': 200.0,
+        'ca': 43.0,
+        'fe': 0.3,
+        'fib': 1.8,
+        'vitC': 41.0,
+      },
+      
+      // 調味料類
+      {
+        'foodId': 18001,
+        'foodName': 'しょうゆ 濃口',
+        'enercKcal': 71.0,
+        'prot': 7.7,
+        'fat': 0.0,
+        'choavl': 10.1,
+        'na': 5700.0,
+        'k': 610.0,
+        'ca': 17.0,
+        'fe': 0.9,
+        'fib': 0.0,
+        'vitC': 0.0,
+      },
+      {
+        'foodId': 18011,
+        'foodName': 'みりん 本みりん',
+        'enercKcal': 241.0,
+        'prot': 0.1,
+        'fat': 0.0,
+        'choavl': 43.2,
+        'na': 11.0,
+        'k': 5.0,
+        'ca': 1.0,
+        'fe': 0.1,
+        'fib': 0.0,
+        'vitC': 0.0,
+      },
+      {
+        'foodId': 17024,
+        'foodName': 'ごま油',
+        'enercKcal': 921.0,
+        'prot': 0.0,
+        'fat': 100.0,
+        'choavl': 0.0,
+        'na': 0.0,
+        'k': 0.0,
+        'ca': 0.0,
+        'fe': 0.0,
+        'fib': 0.0,
+        'vitC': 0.0,
+      },
+      
+      // 主食類
+      {
+        'foodId': 1020,
+        'foodName': 'そうめん・ひやむぎ 乾',
+        'enercKcal': 356.0,
+        'prot': 9.5,
+        'fat': 1.1,
+        'choavl': 72.7,
+        'na': 1800.0,
+        'k': 120.0,
+        'ca': 9.0,
+        'fe': 0.6,
+        'fib': 2.5,
+        'vitC': 0.0,
+      },
+      
+      // その他
+      {
+        'foodId': 19001,
+        'foodName': 'かつおだし',
+        'enercKcal': 3.0,
+        'prot': 0.8,
+        'fat': 0.0,
+        'choavl': 0.1,
+        'na': 270.0,
+        'k': 88.0,
+        'ca': 2.0,
+        'fe': 0.0,
+        'fib': 0.0,
+        'vitC': 0.0,
+      },
+      {
+        'foodId': 10042,
+        'foodName': 'しらす干し 半乾燥品',
+        'enercKcal': 206.0,
+        'prot': 40.5,
+        'fat': 3.6,
+        'choavl': 0.5,
+        'na': 1100.0,
+        'k': 510.0,
+        'ca': 520.0,
+        'fe': 1.8,
+        'fib': 0.0,
+        'vitC': 0.0,
+      },
+    ];
+
+    // サンプルデータをメモリ上のデータベースに保存
+    for (final item in sampleData) {
+      final foodData = JapaneseFoodCompositionTableData(
+        id: item['foodId'] as int,
+        groupId: 1,
+        foodId: item['foodId'] as int,
+        indexId: 1,
+        foodName: item['foodName'] as String,
+        refuse: 0.0,
+        enercKcal: (item['enercKcal'] as double),
+        prot: (item['prot'] as double),
+        fat: (item['fat'] as double),
+        choavl: (item['choavl'] as double),
+        na: (item['na'] as double),
+        k: (item['k'] as double),
+        ca: (item['ca'] as double),
+        fe: (item['fe'] as double),
+        fib: (item['fib'] as double),
+        vitC: (item['vitC'] as double),
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      );
+      
+      _foodDatabase[item['foodName'] as String] = foodData;
+    }
+    
+    print('✅ ${_foodDatabase.length}件の食品データを準備完了');
+  }
+
+  /// レシピ分析
+  Future<void> _analyzeRecipe(int recipeNumber, Map<String, dynamic> recipe) async {
+    print('📄 レシピ$recipeNumber: ${recipe['name']}');
+    print('=' * 70);
+    
+    // 1. 材料抽出
+    print('🔍 STEP 1: 材料抽出');
+    final ingredients = _extractor.extractIngredients(recipe['ingredients'] as String);
+    final stats = _extractor.getExtractionStats(ingredients);
+    
+    print('抽出結果: ${ingredients.length}件');
+    for (int i = 0; i < ingredients.length; i++) {
+      final ingredient = ingredients[i];
+      final confidence = (ingredient.confidence * 100).toStringAsFixed(0);
+      print('  ${i + 1}. ${ingredient.name} | ${ingredient.amount ?? 'N/A'}${ingredient.unit ?? ''} | 信頼度:${confidence}%');
+    }
+    
+    // 2. 食品マッチング
+    print('\n🍱 STEP 2: 食品マッチング');
+    final matchResults = <Map<String, dynamic>>[];
+    
+    for (final ingredient in ingredients) {
+      final matchedFood = _findMatchingFood(ingredient.name);
+      matchResults.add({
+        'ingredient': ingredient,
+        'food': matchedFood,
+        'matched': matchedFood != null,
+      });
+      
+      if (matchedFood != null) {
+        print('  ✅ ${ingredient.name} → ${matchedFood.foodName}');
+      } else {
+        print('  ❌ ${ingredient.name} → マッチなし');
+      }
+    }
+    
+    // 3. 栄養計算
+    print('\n🧮 STEP 3: 栄養計算');
+    final nutritionResult = _calculateNutrition(matchResults);
+    
+    print('栄養成分（総量）:');
+    print('  エネルギー: ${(nutritionResult['totalEnergy'] ?? 0.0).toStringAsFixed(1)} kcal');
+    print('  タンパク質: ${(nutritionResult['totalProtein'] ?? 0.0).toStringAsFixed(1)} g');
+    print('  脂質: ${(nutritionResult['totalFat'] ?? 0.0).toStringAsFixed(1)} g');
+    print('  炭水化物: ${(nutritionResult['totalCarbs'] ?? 0.0).toStringAsFixed(1)} g');
+    print('  食塩相当量: ${(nutritionResult['totalSalt'] ?? 0.0).toStringAsFixed(2)} g');
+    print('  食物繊維: ${(nutritionResult['totalFiber'] ?? 0.0).toStringAsFixed(1)} g');
+    print('  ビタミンC: ${(nutritionResult['totalVitaminC'] ?? 0.0).toStringAsFixed(1)} mg');
+    
+    // 4. PFCバランス
+    final pfcBalance = _calculatePFCBalance(nutritionResult);
+    print('\nPFCバランス:');
+    print('  P（タンパク質）: ${(pfcBalance['protein'] ?? 0.0).toStringAsFixed(1)}%');
+    print('  F（脂質）: ${(pfcBalance['fat'] ?? 0.0).toStringAsFixed(1)}%');
+    print('  C（炭水化物）: ${(pfcBalance['carbs'] ?? 0.0).toStringAsFixed(1)}%');
+    
+    // 5. 統計情報
+    print('\n📊 統計情報:');
+    print('  材料抽出: ${stats['totalCount']}件中${stats['withAmount']}件で数量取得');
+    print('  食品マッチ: ${matchResults.where((r) => r['matched']).length}/${matchResults.length}件成功');
+    print('  平均信頼度: ${(stats['averageConfidence'] * 100).toStringAsFixed(1)}%');
+    
+    final matchRate = (matchResults.where((r) => r['matched']).length / matchResults.length * 100);
+    print('  マッチ率: ${matchRate.toStringAsFixed(1)}%');
+    
+    print('-' * 70);
+  }
+
+  /// 食品マッチング
+  JapaneseFoodCompositionTableData? _findMatchingFood(String ingredientName) {
+    final cleanedName = ingredientName.toLowerCase().trim();
+    
+    // 完全一致チェック
+    for (final entry in _foodDatabase.entries) {
+      if (entry.key.toLowerCase().contains(cleanedName) || 
+          cleanedName.contains(entry.key.toLowerCase())) {
+        return entry.value;
+      }
+    }
+    
+    // 部分一致チェック（キーワードベース）
+    final keywords = {
+      '豚': ['ぶた'],
+      '鶏': ['にわとり'],
+      '玉ねぎ': ['たまねぎ'],
+      'たまねぎ': ['たまねぎ'],
+      'なす': ['なす'],
+      'ピーマン': ['ピーマン'],
+      'いんげん': ['いんげんまめ'],
+      'さやいんげん': ['いんげんまめ'],
+      'キャベツ': ['キャベツ'],
+      '醤油': ['しょうゆ'],
+      'しょうゆ': ['しょうゆ'],
+      'みりん': ['みりん'],
+      'ごま油': ['ごま油'],
+      'そうめん': ['そうめん'],
+      'だし': ['かつおだし'],
+      'ちりめんじゃこ': ['しらす'],
+      'じゃこ': ['しらす'],
+    };
+    
+    for (final keywordEntry in keywords.entries) {
+      if (cleanedName.contains(keywordEntry.key)) {
+        for (final searchTerm in keywordEntry.value) {
+          for (final entry in _foodDatabase.entries) {
+            if (entry.key.contains(searchTerm)) {
+              return entry.value;
+            }
+          }
+        }
+      }
+    }
+    
+    return null;
+  }
+
+  /// 栄養計算
+  Map<String, double> _calculateNutrition(List<Map<String, dynamic>> matchResults) {
+    double totalEnergy = 0;
+    double totalProtein = 0;
+    double totalFat = 0;
+    double totalCarbs = 0;
+    double totalSalt = 0;
+    double totalFiber = 0;
+    double totalVitaminC = 0;
+    
+    for (final result in matchResults) {
+      if (result['matched']) {
+        final ingredient = result['ingredient'] as Ingredient;
+        final food = result['food'] as JapaneseFoodCompositionTableData;
+        
+        // 重量をグラムに変換
+        final amountInGrams = _convertToGrams(ingredient.amount ?? 0, ingredient.unit);
+        final multiplier = amountInGrams / 100; // 100gあたりの値から実際の量を計算
+        
+        totalEnergy += (food.enercKcal ?? 0) * multiplier;
+        totalProtein += (food.prot ?? 0) * multiplier;
+        totalFat += (food.fat ?? 0) * multiplier;
+        totalCarbs += (food.choavl ?? 0) * multiplier;
+        totalSalt += (food.na ?? 0) * multiplier * 2.54 / 1000; // ナトリウムから食塩相当量
+        totalFiber += (food.fib ?? 0) * multiplier;
+        totalVitaminC += (food.vitC ?? 0) * multiplier;
+      }
+    }
+    
+    return {
+      'totalEnergy': totalEnergy,
+      'totalProtein': totalProtein,
+      'totalFat': totalFat,
+      'totalCarbs': totalCarbs,
+      'totalSalt': totalSalt,
+      'totalFiber': totalFiber,
+      'totalVitaminC': totalVitaminC,
+    };
+  }
+
+  /// 単位変換
+  double _convertToGrams(double amount, String? unit) {
+    final normalizedUnit = (unit ?? '').toLowerCase();
+    
+    // 基本的な単位変換表
+    final conversionMap = {
+      'g': 1.0,
+      'kg': 1000.0,
+      'ml': 1.0, // 液体は1ml=1gと仮定
+      '個': 100.0, // 野菜1個の平均重量
+      'コ': 100.0,
+      '本': 50.0,  // 野菜1本の平均重量
+      '枚': 100.0, // 肉1枚の平均重量
+      '束': 100.0,
+      '大さじ': 15.0,
+      '小さじ': 5.0,
+    };
+    
+    return amount * (conversionMap[normalizedUnit] ?? 1.0);
+  }
+
+  /// PFCバランス計算
+  Map<String, double> _calculatePFCBalance(Map<String, double> nutrition) {
+    final proteinCal = nutrition['totalProtein']! * 4; // 1g = 4kcal
+    final fatCal = nutrition['totalFat']! * 9; // 1g = 9kcal
+    final carbsCal = nutrition['totalCarbs']! * 4; // 1g = 4kcal
+    final total = proteinCal + fatCal + carbsCal;
+    
+    if (total == 0) {
+      return {'protein': 0, 'fat': 0, 'carbs': 0};
+    }
+    
+    return {
+      'protein': (proteinCal / total) * 100,
+      'fat': (fatCal / total) * 100,
+      'carbs': (carbsCal / total) * 100,
+    };
+  }
+}
+
+void main() async {
+  final test = RecipeNutritionAnalysisTest();
+  await test.runTest();
+  exit(0);
+}


### PR DESCRIPTION
## 概要
レシピから材料を抽出し、栄養情報を自動計算する機能と、材料管理UIの改善を実装しました。

## 主な変更内容

### 🔬 栄養分析機能
- **材料抽出**: 規則ベースによる日本語レシピからの材料抽出
- **栄養計算**: 日本食品成分表2020に基づく栄養価自動計算
- **データマッチング**: 材料名の多段階マッチング（完全一致→部分一致→シノニム→ファジー）
- **栄養データベース**: 基本食品データベース実装

### 🎨 UI改善
- **材料カード**: 各材料にエネルギー、タンパク質、脂質、炭水化物を表示
- **レイアウト調整**: 分析ボタンを材料リストタイトル横に移動
- **情報整理**: その他栄養素情報を非表示、1人前あたり表示に統一
- **タグ機能**: 一時的に非表示設定

### 🗄️ データベース拡張
- **材料保存**: 材料リストのJSON保存機能
- **スキーマ更新**: 栄養情報フィールド追加
- **マイグレーション**: 既存データとの互換性確保

### 🐛 バグ修正
- **文字化け**: UTF-8エンコーディング問題修正
- **WebView**: 404エラー問題解決
- **抽出精度**: 材料抽出パターンの改善

## テスト内容
- 味の素パーク、レタスクラブ等のレシピサイトでの材料抽出確認
- 栄養価計算の精度検証
- UI動作確認

## 技術スタック
- Flutter/Dart
- Drift (SQLite ORM)
- Riverpod (状態管理)
- 日本食品成分表2020データ