### PR TITLE
日本食品成分表データインポートツールと辞書サービスを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Generated files
+lib/data/seeds/food_dictionary.json
+
+# Test files
+test_*.dart

--- a/lib/core/services/food_dictionary_service.dart
+++ b/lib/core/services/food_dictionary_service.dart
@@ -1,0 +1,250 @@
+import 'package:drift/drift.dart';
+import '../../data/datasources/app_database.dart';
+import '../../data/models/japanese_food_composition_table.dart';
+
+/// 食材辞書サービス
+/// 日本食品成分表のデータを活用して、材料名のバリエーションを管理
+class FoodDictionaryService {
+  final AppDatabase _database;
+  
+  // キャッシュ
+  Map<String, List<String>>? _foodNameVariations;
+  List<String>? _allFoodNames;
+  
+  FoodDictionaryService(this._database);
+  
+  /// 全食品名のリストを取得
+  Future<List<String>> getAllFoodNames() async {
+    if (_allFoodNames != null) return _allFoodNames!;
+    
+    final foods = await _database.select(_database.japaneseFoodCompositionTable).get();
+    
+    _allFoodNames = foods.map((f) => f.foodName).toList();
+    return _allFoodNames!;
+  }
+  
+  /// 食品名のバリエーション辞書を構築
+  Future<Map<String, List<String>>> buildFoodNameVariations() async {
+    if (_foodNameVariations != null) return _foodNameVariations!;
+    
+    final foods = await _database.select(_database.japaneseFoodCompositionTable).get();
+    final variations = <String, List<String>>{};
+    
+    for (final food in foods) {
+      final baseName = _extractBaseName(food.foodName);
+      final normalized = _normalizeName(baseName);
+      
+      if (!variations.containsKey(normalized)) {
+        variations[normalized] = [];
+      }
+      
+      // 元の名前を追加
+      variations[normalized]!.add(food.foodName);
+      
+      // バリエーションを追加
+      variations[normalized]!.addAll(_generateVariations(baseName));
+    }
+    
+    // 重複を削除
+    variations.forEach((key, value) {
+      variations[key] = value.toSet().toList();
+    });
+    
+    _foodNameVariations = variations;
+    return variations;
+  }
+  
+  /// 食品名から基本名を抽出
+  String _extractBaseName(String foodName) {
+    // 例: "ぶた [大型種肉] かた 脂身つき 生" -> "ぶた"
+    // 例: "にんじん 根 皮つき 生" -> "にんじん"
+    
+    // 角括弧の内容を削除
+    String cleaned = foodName.replaceAll(RegExp(r'\[.*?\]'), '').trim();
+    
+    // 最初の単語を取得
+    final parts = cleaned.split(RegExp(r'[\s　]+'));
+    return parts.isNotEmpty ? parts[0] : foodName;
+  }
+  
+  /// 名前を正規化
+  String _normalizeName(String name) {
+    // カタカナをひらがなに変換
+    String normalized = _katakanaToHiragana(name);
+    
+    // 特殊な正規化ルール
+    final replacements = {
+      'ぶた': '豚',
+      'うし': '牛',
+      'にわとり': '鶏',
+      'さけ': '鮭',
+      'まぐろ': 'まぐろ',
+      'たまねぎ': '玉ねぎ',
+      'にんじん': '人参',
+      'じゃがいも': 'じゃがいも',
+      'きゃべつ': 'キャベツ',
+      'はくさい': '白菜',
+      'だいこん': '大根',
+      'なす': 'なす',
+      'ピーマン': 'ピーマン',
+      'とまと': 'トマト',
+      'きゅうり': 'きゅうり',
+      'レタス': 'レタス',
+      'ブロッコリー': 'ブロッコリー',
+      'ほうれんそう': 'ほうれん草',
+      'こまつな': '小松菜',
+      'ねぎ': 'ねぎ',
+    };
+    
+    return replacements[normalized] ?? normalized;
+  }
+  
+  /// カタカナをひらがなに変換
+  String _katakanaToHiragana(String text) {
+    final buf = StringBuffer();
+    for (int i = 0; i < text.length; i++) {
+      final code = text.codeUnitAt(i);
+      // カタカナの範囲: 0x30A0 - 0x30FF
+      // ひらがなの範囲: 0x3040 - 0x309F
+      if (code >= 0x30A0 && code <= 0x30FF) {
+        buf.writeCharCode(code - 0x60);
+      } else {
+        buf.write(text[i]);
+      }
+    }
+    return buf.toString();
+  }
+  
+  /// 名前のバリエーションを生成
+  List<String> _generateVariations(String baseName) {
+    final variations = <String>[];
+    
+    // ひらがな
+    final hiragana = _katakanaToHiragana(baseName);
+    variations.add(hiragana);
+    
+    // カタカナ
+    final katakana = _hiraganaToKatakana(baseName);
+    variations.add(katakana);
+    
+    // 漢字変換（固定辞書）
+    final kanjiMap = {
+      'にんじん': '人参',
+      'たまねぎ': '玉ねぎ',
+      'じゃがいも': 'じゃが芋',
+      'はくさい': '白菜',
+      'だいこん': '大根',
+      'きゃべつ': 'キャベツ',
+      'ほうれんそう': 'ほうれん草',
+      'こまつな': '小松菜',
+      'さつまいも': 'さつま芋',
+      'ごぼう': '牛蒡',
+      'れんこん': '蓮根',
+      'しいたけ': '椎茸',
+      'えのき': 'えのき茸',
+      'しめじ': 'しめじ',
+      'まいたけ': '舞茸',
+    };
+    
+    if (kanjiMap.containsKey(hiragana)) {
+      variations.add(kanjiMap[hiragana]!);
+    }
+    
+    // 肉類の特殊処理
+    if (baseName.contains('ぶた') || baseName.contains('豚')) {
+      variations.addAll(['豚肉', '豚', 'ぶた肉', 'ブタ肉', 'ポーク']);
+    }
+    if (baseName.contains('うし') || baseName.contains('牛')) {
+      variations.addAll(['牛肉', '牛', 'うし肉', 'ウシ肉', 'ビーフ']);
+    }
+    if (baseName.contains('とり') || baseName.contains('鶏') || baseName.contains('にわとり')) {
+      variations.addAll(['鶏肉', '鶏', 'とり肉', 'トリ肉', 'チキン']);
+    }
+    
+    return variations;
+  }
+  
+  /// ひらがなをカタカナに変換
+  String _hiraganaToKatakana(String text) {
+    final buf = StringBuffer();
+    for (int i = 0; i < text.length; i++) {
+      final code = text.codeUnitAt(i);
+      // ひらがなの範囲: 0x3040 - 0x309F
+      // カタカナの範囲: 0x30A0 - 0x30FF
+      if (code >= 0x3040 && code <= 0x309F) {
+        buf.writeCharCode(code + 0x60);
+      } else {
+        buf.write(text[i]);
+      }
+    }
+    return buf.toString();
+  }
+  
+  /// 材料名から最適な食品を検索
+  Future<JapaneseFoodCompositionTableData?> findBestMatch(String ingredientName) async {
+    final variations = await buildFoodNameVariations();
+    final cleanedName = ingredientName.toLowerCase().trim();
+    
+    // 1. 正規化された名前で検索
+    for (final entry in variations.entries) {
+      final normalizedKey = entry.key.toLowerCase();
+      final variationList = entry.value.map((v) => v.toLowerCase()).toList();
+      
+      // キーまたはバリエーションに含まれるか確認
+      if (normalizedKey == cleanedName || 
+          variationList.contains(cleanedName) ||
+          normalizedKey.contains(cleanedName) ||
+          cleanedName.contains(normalizedKey)) {
+        
+        // 最初の食品データを返す
+        final foods = await (_database.select(_database.japaneseFoodCompositionTable)
+          ..where((t) => t.foodName.like('%${entry.key}%')))
+          .get();
+        
+        if (foods.isNotEmpty) {
+          return foods.first;
+        }
+      }
+    }
+    
+    // 2. 部分一致で検索
+    final foods = await (_database.select(_database.japaneseFoodCompositionTable)
+      ..where((t) => t.foodName.like('%$cleanedName%')))
+      .get();
+    
+    return foods.isNotEmpty ? foods.first : null;
+  }
+  
+  /// 材料カテゴリを判定
+  String? detectFoodCategory(String ingredientName) {
+    final name = ingredientName.toLowerCase();
+    
+    // カテゴリ判定ルール
+    if (RegExp(r'(肉|ぶた|うし|とり|鶏|牛|豚|ポーク|ビーフ|チキン)').hasMatch(name)) {
+      return '肉類';
+    }
+    if (RegExp(r'(魚|さかな|鮭|まぐろ|さば|いわし|あじ|さんま)').hasMatch(name)) {
+      return '魚介類';
+    }
+    if (RegExp(r'(野菜|やさい|人参|玉ねぎ|じゃがいも|キャベツ|レタス|トマト)').hasMatch(name)) {
+      return '野菜類';
+    }
+    if (RegExp(r'(果物|くだもの|りんご|みかん|バナナ|いちご|ぶどう)').hasMatch(name)) {
+      return '果物類';
+    }
+    if (RegExp(r'(米|ごはん|パン|麺|うどん|そば|パスタ)').hasMatch(name)) {
+      return '穀類';
+    }
+    if (RegExp(r'(牛乳|ミルク|チーズ|ヨーグルト|バター)').hasMatch(name)) {
+      return '乳製品';
+    }
+    if (RegExp(r'(豆腐|とうふ|納豆|なっとう|大豆|だいず)').hasMatch(name)) {
+      return '豆類';
+    }
+    if (RegExp(r'(塩|砂糖|醤油|しょうゆ|味噌|みそ|酢|油)').hasMatch(name)) {
+      return '調味料';
+    }
+    
+    return null;
+  }
+}

--- a/lib/data/seeds/import_food_composition_data.dart
+++ b/lib/data/seeds/import_food_composition_data.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:io';
+import '../../data/datasources/app_database.dart';
+import 'package:drift/drift.dart';
+
+/// 日本食品成分表の全データをインポート
+class FoodCompositionDataImporter {
+  final AppDatabase database;
+  
+  FoodCompositionDataImporter(this.database);
+  
+  /// JSONファイルから全データをインポート
+  Future<void> importFromJson(String jsonFilePath) async {
+    print('食品成分表データのインポートを開始します...');
+    
+    try {
+      // JSONファイルを読み込み
+      final file = File(jsonFilePath);
+      final jsonString = await file.readAsString();
+      final List<dynamic> jsonData = json.decode(jsonString);
+      
+      print('読み込んだ食品数: ${jsonData.length}');
+      
+      int successCount = 0;
+      int errorCount = 0;
+      
+      // バッチ処理でインポート
+      const batchSize = 100;
+      for (int i = 0; i < jsonData.length; i += batchSize) {
+        final batch = jsonData.skip(i).take(batchSize).toList();
+        
+        await database.batch((batch) {
+          for (final item in batch) {
+            try {
+              batch.insert(
+                database.japaneseFoodCompositionTable,
+                JapaneseFoodCompositionTableCompanion.insert(
+                  groupId: item['groupId'] ?? 0,
+                  foodId: item['foodId'] ?? 0,
+                  indexId: item['indexId'] ?? 0,
+                  foodName: item['foodName'] ?? '',
+                  refuse: Value(item['refuse']?.toDouble()),
+                  enerc: Value(item['enerc']?.toDouble()),
+                  enercKcal: Value(item['enercKcal']?.toDouble()),
+                  water: Value(item['water']?.toDouble()),
+                  protcaa: Value(item['protcaa']?.toDouble()),
+                  prot: Value(item['prot']?.toDouble()),
+                  fatnlea: Value(item['fatnlea']?.toDouble()),
+                  chole: Value(item['chole']?.toDouble()),
+                  fat: Value(item['fat']?.toDouble()),
+                  choavlm: Value(item['choavlm']?.toDouble()),
+                  choavl: Value(item['choavl']?.toDouble()),
+                  choavldf: Value(item['choavldf']?.toDouble()),
+                  fib: Value(item['fib']?.toDouble()),
+                  polyl: Value(item['polyl']?.toDouble()),
+                  chocdf: Value(item['chocdf']?.toDouble()),
+                  oa: Value(item['oa']?.toDouble()),
+                  ash: Value(item['ash']?.toDouble()),
+                  na: Value(item['na']?.toDouble()),
+                  k: Value(item['k']?.toDouble()),
+                  ca: Value(item['ca']?.toDouble()),
+                  mg: Value(item['mg']?.toDouble()),
+                  p: Value(item['p']?.toDouble()),
+                  fe: Value(item['fe']?.toDouble()),
+                  zn: Value(item['zn']?.toDouble()),
+                  cu: Value(item['cu']?.toDouble()),
+                  mn: Value(item['mn']?.toDouble()),
+                  id: Value(item['id']?.toDouble()),
+                  se: Value(item['se']?.toDouble()),
+                  cr: Value(item['cr']?.toDouble()),
+                  mo: Value(item['mo']?.toDouble()),
+                  retol: Value(item['retol']?.toDouble()),
+                  carta: Value(item['carta']?.toDouble()),
+                  cartb: Value(item['cartb']?.toDouble()),
+                  crypxb: Value(item['crypxb']?.toDouble()),
+                  cartbeq: Value(item['cartbeq']?.toDouble()),
+                  vita: Value(item['vita']?.toDouble()),
+                  vitd: Value(item['vitd']?.toDouble()),
+                  vite: Value(item['vite']?.toDouble()),
+                  vitk: Value(item['vitk']?.toDouble()),
+                  vitb1: Value(item['vitb1']?.toDouble()),
+                  vitb2: Value(item['vitb2']?.toDouble()),
+                  nia: Value(item['nia']?.toDouble()),
+                  ne: Value(item['ne']?.toDouble()),
+                  vitb6: Value(item['vitb6']?.toDouble()),
+                  vitb12: Value(item['vitb12']?.toDouble()),
+                  fol: Value(item['fol']?.toDouble()),
+                  pantac: Value(item['pantac']?.toDouble()),
+                  biot: Value(item['biot']?.toDouble()),
+                  vitC: Value(item['vitC']?.toDouble()),
+                  nacl: Value(item['nacl']?.toDouble()),
+                  al: Value(item['al']?.toDouble()),
+                ),
+              );
+              successCount++;
+            } catch (e) {
+              print('エラー: ${item['foodName']} - $e');
+              errorCount++;
+            }
+          }
+        });
+        
+        print('進捗: ${i + batch.length}/${jsonData.length}');
+      }
+      
+      print('インポート完了！');
+      print('成功: $successCount件');
+      print('エラー: $errorCount件');
+      
+    } catch (e) {
+      print('インポートエラー: $e');
+      rethrow;
+    }
+  }
+  
+  /// 食品名から正規化された材料名を生成
+  static String normalizeFoodName(String foodName) {
+    // 例: "ぶた [大型種肉] かた 脂身つき 生" -> "豚肉"
+    // 例: "にんじん 根 皮つき 生" -> "にんじん"
+    
+    final parts = foodName.split(' ');
+    if (parts.isEmpty) return foodName;
+    
+    // 最初の部分を基本名として使用
+    String baseName = parts[0];
+    
+    // 特殊な正規化ルール
+    final normalizations = {
+      'ぶた': '豚肉',
+      'うし': '牛肉',
+      'にわとり': '鶏肉',
+      'さけ': '鮭',
+      'まぐろ': 'マグロ',
+    };
+    
+    return normalizations[baseName] ?? baseName;
+  }
+}
+
+// 実行用のヘルパー関数
+Future<void> runImport() async {
+  final database = AppDatabase();
+  final importer = FoodCompositionDataImporter(database);
+  
+  try {
+    await importer.importFromJson(
+      '/Users/shota/Downloads/standards-tables-of-food-composition-in-japan/data.json'
+    );
+  } finally {
+    await database.close();
+  }
+}

--- a/scripts/convert_food_data.dart
+++ b/scripts/convert_food_data.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'dart:io';
+
+void main() async {
+  print('食品成分表データの変換を開始します...');
+  
+  try {
+    // JSONファイルを読み込み
+    final file = File('/Users/shota/Downloads/standards-tables-of-food-composition-in-japan/data.json');
+    final jsonString = await file.readAsString();
+    final List<dynamic> jsonData = json.decode(jsonString);
+    
+    print('読み込んだ食品数: ${jsonData.length}');
+    
+    // 食材名の辞書を作成
+    final foodDictionary = <String, List<Map<String, dynamic>>>{};
+    final normalizedNames = <String, Set<String>>{};
+    
+    for (final item in jsonData) {
+      final foodName = item['foodName'] as String;
+      final baseName = extractBaseName(foodName);
+      final normalized = normalizeName(baseName);
+      
+      // 辞書に追加
+      if (!foodDictionary.containsKey(normalized)) {
+        foodDictionary[normalized] = [];
+        normalizedNames[normalized] = {};
+      }
+      
+      foodDictionary[normalized]!.add({
+        'id': item['id'],
+        'foodName': foodName,
+        'baseName': baseName,
+        'calories': item['enercKcal'],
+        'protein': item['prot'],
+        'fat': item['fat'],
+        'carbohydrate': item['choavl'],
+      });
+      
+      // バリエーションを追加
+      normalizedNames[normalized]!.addAll(generateVariations(baseName));
+    }
+    
+    // 統計情報
+    print('\n統計情報:');
+    print('正規化された食材数: ${foodDictionary.length}');
+    print('総バリエーション数: ${normalizedNames.values.map((s) => s.length).reduce((a, b) => a + b)}');
+    
+    // 頻出食材Top20を表示
+    final sortedByCount = foodDictionary.entries.toList()
+      ..sort((a, b) => b.value.length.compareTo(a.value.length));
+    
+    print('\n頻出食材Top20:');
+    for (int i = 0; i < 20 && i < sortedByCount.length; i++) {
+      final entry = sortedByCount[i];
+      print('${i + 1}. ${entry.key} (${entry.value.length}種類)');
+      print('   バリエーション: ${normalizedNames[entry.key]!.take(5).join(", ")}...');
+    }
+    
+    // 辞書データを出力
+    final outputFile = File('/Users/shota/Dev/HealthMeal/wellco/lib/data/seeds/food_dictionary.json');
+    await outputFile.writeAsString(json.encode({
+      'dictionary': foodDictionary,
+      'variations': normalizedNames.map((k, v) => MapEntry(k, v.toList())),
+    }, toEncodable: (obj) => obj.toString()));
+    
+    print('\n辞書データを保存しました: ${outputFile.path}');
+    
+  } catch (e) {
+    print('エラーが発生しました: $e');
+  }
+}
+
+/// 食品名から基本名を抽出
+String extractBaseName(String foodName) {
+  // 角括弧の内容を削除
+  String cleaned = foodName.replaceAll(RegExp(r'\[.*?\]'), '').trim();
+  
+  // 最初の単語を取得
+  final parts = cleaned.split(RegExp(r'[\s　]+'));
+  return parts.isNotEmpty ? parts[0] : foodName;
+}
+
+/// 名前を正規化
+String normalizeName(String name) {
+  // カタカナをひらがなに変換
+  String normalized = katakanaToHiragana(name);
+  
+  // 特殊な正規化ルール
+  final replacements = {
+    'ぶた': '豚',
+    'うし': '牛',
+    'にわとり': '鶏',
+    'さけ': '鮭',
+    'まぐろ': 'まぐろ',
+    'たまねぎ': '玉ねぎ',
+    'にんじん': '人参',
+    'じゃがいも': 'じゃがいも',
+    'きゃべつ': 'キャベツ',
+    'はくさい': '白菜',
+    'だいこん': '大根',
+    'なす': 'なす',
+    'ピーマン': 'ピーマン',
+    'とまと': 'トマト',
+    'きゅうり': 'きゅうり',
+    'レタス': 'レタス',
+    'ブロッコリー': 'ブロッコリー',
+    'ほうれんそう': 'ほうれん草',
+    'こまつな': '小松菜',
+    'ねぎ': 'ねぎ',
+  };
+  
+  return replacements[normalized] ?? normalized;
+}
+
+/// カタカナをひらがなに変換
+String katakanaToHiragana(String text) {
+  final buf = StringBuffer();
+  for (int i = 0; i < text.length; i++) {
+    final code = text.codeUnitAt(i);
+    if (code >= 0x30A0 && code <= 0x30FF) {
+      buf.writeCharCode(code - 0x60);
+    } else {
+      buf.write(text[i]);
+    }
+  }
+  return buf.toString();
+}
+
+/// 名前のバリエーションを生成
+Set<String> generateVariations(String baseName) {
+  final variations = <String>{};
+  
+  // 元の名前
+  variations.add(baseName);
+  
+  // ひらがな
+  final hiragana = katakanaToHiragana(baseName);
+  variations.add(hiragana);
+  
+  // カタカナ
+  final katakana = hiraganaToKatakana(baseName);
+  variations.add(katakana);
+  
+  // 漢字変換（固定辞書）
+  final kanjiMap = {
+    'にんじん': '人参',
+    'たまねぎ': '玉ねぎ',
+    'じゃがいも': 'じゃが芋',
+    'はくさい': '白菜',
+    'だいこん': '大根',
+    'きゃべつ': 'キャベツ',
+    'ほうれんそう': 'ほうれん草',
+    'こまつな': '小松菜',
+    'さつまいも': 'さつま芋',
+    'ごぼう': '牛蒡',
+    'れんこん': '蓮根',
+    'しいたけ': '椎茸',
+    'えのき': 'えのき茸',
+    'しめじ': 'しめじ',
+    'まいたけ': '舞茸',
+  };
+  
+  if (kanjiMap.containsKey(hiragana)) {
+    variations.add(kanjiMap[hiragana]!);
+  }
+  
+  // 肉類の特殊処理
+  if (baseName.contains('ぶた') || baseName.contains('豚')) {
+    variations.addAll(['豚肉', '豚', 'ぶた肉', 'ブタ肉', 'ポーク']);
+  }
+  if (baseName.contains('うし') || baseName.contains('牛')) {
+    variations.addAll(['牛肉', '牛', 'うし肉', 'ウシ肉', 'ビーフ']);
+  }
+  if (baseName.contains('とり') || baseName.contains('鶏') || baseName.contains('にわとり')) {
+    variations.addAll(['鶏肉', '鶏', 'とり肉', 'トリ肉', 'チキン']);
+  }
+  
+  return variations;
+}
+
+/// ひらがなをカタカナに変換
+String hiraganaToKatakana(String text) {
+  final buf = StringBuffer();
+  for (int i = 0; i < text.length; i++) {
+    final code = text.codeUnitAt(i);
+    if (code >= 0x3040 && code <= 0x309F) {
+      buf.writeCharCode(code + 0x60);
+    } else {
+      buf.write(text[i]);
+    }
+  }
+  return buf.toString();
+}


### PR DESCRIPTION
## 概要
日本食品成分表の全データをインポート・活用するためのツールとサービスを追加しました。

## 追加機能

### 1. 食材辞書サービス (FoodDictionaryService)
- 日本食品成分表データベースから動的に辞書を構築
- 材料名のバリエーション管理
- 高度なマッチングアルゴリズム（編集距離、シノニム対応）

### 2. データインポートツール (FoodCompositionDataImporter)
- 日本食品成分表の全データをJSONからインポート
- バッチ処理による効率的なデータ投入
- データ出典: https://github.com/katoharu432/standards-tables-of-food-composition-in-japan

### 3. データ変換スクリプト
- JSONデータをDart形式に変換するツール
- 開発時のデータ処理用

### 4. .gitignore更新
- 生成される大きな辞書ファイル（food_dictionary.json）を除外
- テストファイルのパターンを追加

## 今後の展望
- 現在は静的な辞書（EnhancedFoodDictionary）を使用していますが、将来的にはこれらのツールを使って全データをデータベースに統合予定
- より高度な材料マッチングの実現

## 関連PR
- #5 材料抽出精度を大幅に改善