### PR TITLE
一時的に未実装機能を非表示化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ migrate_working_dir/
 .flutter-plugins-dependencies
 .pub-cache/
 .pub/
-/build/
+**/build/
 
 # Symbolication related
 app.*.symbols

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -280,13 +280,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -376,13 +372,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -10,7 +10,7 @@ import '../providers/database_provider.dart';
 import '../widgets/nutrition_summary_card.dart';
 import '../widgets/weight_chart_card.dart';
 import '../widgets/steps_progress_card.dart';
-import '../widgets/quick_actions_card.dart';
+// import '../widgets/quick_actions_card.dart'; // 一時的に非表示
 
 class HomePage extends HookConsumerWidget {
   const HomePage({super.key});
@@ -116,9 +116,9 @@ class HomePage extends HookConsumerWidget {
                 ),
                 SizedBox(height: AppConstants.paddingM.h),
 
-                // クイックアクション
-                const QuickActionsCard(),
-                SizedBox(height: AppConstants.paddingL.h),
+                // クイックアクション（一時的に非表示）
+                // const QuickActionsCard(),
+                // SizedBox(height: AppConstants.paddingL.h),
               ],
             ),
           ),

--- a/lib/presentation/pages/meal_management_page.dart
+++ b/lib/presentation/pages/meal_management_page.dart
@@ -513,19 +513,19 @@ class MealManagementPage extends HookConsumerWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 在庫管理
-          Expanded(
-            child: _buildKanbanColumn(
-              title: '在庫管理',
-              color: AppColors.primary,
-              items: [
-                _buildStockItem('🥬', '白菜', '1/2個', '3日後'),
-                _buildStockItem('🥚', '卵', '8個', '5日後'),
-                _buildStockItem('🍗', '鶏肉', '300g', '明日'),
-              ],
-            ),
-          ),
-          SizedBox(width: AppConstants.paddingS.w),
+          // 在庫管理（一時的に非表示）
+          // Expanded(
+          //   child: _buildKanbanColumn(
+          //     title: '在庫管理',
+          //     color: AppColors.primary,
+          //     items: [
+          //       _buildStockItem('🥬', '白菜', '1/2個', '3日後'),
+          //       _buildStockItem('🥚', '卵', '8個', '5日後'),
+          //       _buildStockItem('🍗', '鶏肉', '300g', '明日'),
+          //     ],
+          //   ),
+          // ),
+          // SizedBox(width: AppConstants.paddingS.w),
           
           // レシピ
           Expanded(
@@ -585,34 +585,35 @@ class MealManagementPage extends HookConsumerWidget {
     );
   }
 
-  Widget _buildStockItem(String emoji, String name, String quantity, String expiry) {
-    return Container(
-      margin: EdgeInsets.only(bottom: AppConstants.paddingS.h),
-      padding: EdgeInsets.all(AppConstants.paddingS.w),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
-        border: Border.all(color: AppColors.primary.withOpacity(0.2)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '$emoji $name',
-            style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
-          ),
-          Text(
-            quantity,
-            style: AppTextStyles.caption,
-          ),
-          Text(
-            expiry,
-            style: AppTextStyles.caption.copyWith(color: AppColors.warning),
-          ),
-        ],
-      ),
-    );
-  }
+  // 在庫管理アイテム（一時的に非表示のため未使用）
+  // Widget _buildStockItem(String emoji, String name, String quantity, String expiry) {
+  //   return Container(
+  //     margin: EdgeInsets.only(bottom: AppConstants.paddingS.h),
+  //     padding: EdgeInsets.all(AppConstants.paddingS.w),
+  //     decoration: BoxDecoration(
+  //       color: AppColors.surface,
+  //       borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
+  //       border: Border.all(color: AppColors.primary.withOpacity(0.2)),
+  //     ),
+  //     child: Column(
+  //       crossAxisAlignment: CrossAxisAlignment.start,
+  //       children: [
+  //         Text(
+  //           '$emoji $name',
+  //           style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
+  //         ),
+  //         Text(
+  //           quantity,
+  //           style: AppTextStyles.caption,
+  //         ),
+  //         Text(
+  //           expiry,
+  //           style: AppTextStyles.caption.copyWith(color: AppColors.warning),
+  //         ),
+  //       ],
+  //     ),
+  //   );
+  // }
 
   Widget _buildRecipeItem(String name, String calories, String protein) {
     return Container(


### PR DESCRIPTION
## 概要
MVPリリースに向けて、未実装の機能を一時的に非表示にしました。

## 変更内容
- ホームタブのクイックアクションカードを非表示
- 食事管理タブの在庫管理セクションを非表示

## 対応詳細
### ホームタブ
- `QuickActionsCard`コンポーネントの表示をコメントアウト
- 関連するimport文もコメントアウト

### 食事管理タブ  
- カンバンビューから在庫管理カラムを削除
- 未使用となった`_buildStockItem`メソッドをコメントアウト

## 注意事項
- コードは削除せずコメントアウトで保持
- 将来的な再実装時に参照可能な状態を維持

## テスト確認
- [x] ホームタブでクイックアクションが非表示になることを確認
- [x] 食事管理タブで在庫管理が非表示になることを確認
- [x] flutter analyzeでエラーがないことを確認