### PR TITLE
feat: レシピと食品の統合管理システムを実装

### DIFF
--- a/lib/core/services/food_product_extraction_service.dart
+++ b/lib/core/services/food_product_extraction_service.dart
@@ -1,0 +1,296 @@
+import 'package:html/dom.dart';
+import 'dart:convert';
+import '../services/nutrition_extraction_service.dart';
+
+/// 食品商品情報を抽出するサービス
+class FoodProductExtractionService {
+  final NutritionExtractionService _nutritionExtractor = NutritionExtractionService();
+  
+  /// HTML文書から食品商品情報を抽出
+  FoodProductInfo? extractFoodProductFromHtml(Document document, String url) {
+    print('デバッグ: 食品商品情報の抽出を開始');
+    
+    // 1. JSON-LD構造化データから商品情報を抽出
+    final jsonLdProduct = _extractFromJsonLD(document);
+    if (jsonLdProduct != null) {
+      print('デバッグ: JSON-LDから商品情報を抽出: ${jsonLdProduct.name}');
+      return jsonLdProduct.copyWith(sourceUrl: url);
+    }
+    
+    // 2. OpenGraph/メタデータから商品情報を抽出
+    final ogpProduct = _extractFromOGP(document);
+    if (ogpProduct != null) {
+      print('デバッグ: OGPから商品情報を抽出: ${ogpProduct.name}');
+      return ogpProduct.copyWith(sourceUrl: url);
+    }
+    
+    // 3. HTMLパターンから商品情報を抽出
+    final htmlProduct = _extractFromHTML(document);
+    if (htmlProduct != null) {
+      print('デバッグ: HTMLパターンから商品情報を抽出: ${htmlProduct.name}');
+      return htmlProduct.copyWith(sourceUrl: url);
+    }
+    
+    print('デバッグ: 食品商品情報は見つかりませんでした');
+    return null;
+  }
+  
+  /// JSON-LD構造化データから商品情報を抽出
+  FoodProductInfo? _extractFromJsonLD(Document document) {
+    final scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    
+    for (final script in scripts) {
+      try {
+        final jsonText = script.text;
+        final jsonData = json.decode(jsonText);
+        
+        // Productスキーマを探す
+        if (jsonData is Map<String, dynamic> && jsonData['@type'] == 'Product') {
+          final name = jsonData['name'] as String?;
+          if (name == null || name.isEmpty) continue;
+          
+          // 基本商品情報
+          final sku = jsonData['sku'] as String?;
+          final brand = jsonData['brand'] as String?;
+          final description = jsonData['description'] as String?;
+          final size = jsonData['size'] as String?;
+          
+          // 画像URL
+          List<String> imageUrls = [];
+          final images = jsonData['image'];
+          if (images is List) {
+            imageUrls = images.map((img) => img.toString()).toList();
+          } else if (images is String) {
+            imageUrls = [images];
+          }
+          
+          // 価格情報
+          double? price;
+          final offers = jsonData['offers'];
+          if (offers is Map) {
+            final priceStr = offers['price']?.toString();
+            if (priceStr != null) {
+              price = double.tryParse(priceStr);
+            }
+          }
+          
+          // 栄養情報を抽出
+          final nutrition = _extractNutritionFromJsonLD(jsonData);
+          
+          // HTMLからの栄養情報も試す（JSON-LDに栄養情報がない場合）
+          final htmlNutrition = nutrition ?? _nutritionExtractor.extractNutritionFromHtml(document);
+          
+          return FoodProductInfo(
+            name: name,
+            productCode: sku,
+            brand: brand,
+            description: description,
+            size: size,
+            imageUrl: imageUrls.isNotEmpty ? imageUrls.first : null,
+            price: price,
+            nutrition: htmlNutrition,
+            nutritionSource: htmlNutrition != null ? (nutrition != null ? 'JSON-LD商品データ' : htmlNutrition.source) : null,
+          );
+        }
+      } catch (e) {
+        print('JSON-LD解析エラー: $e');
+        continue;
+      }
+    }
+    
+    return null;
+  }
+  
+  /// JSON-LDから栄養情報を抽出
+  NutritionInfo? _extractNutritionFromJsonLD(Map<String, dynamic> jsonData) {
+    final nutrition = jsonData['nutrition'];
+    if (nutrition is Map<String, dynamic>) {
+      final calories = _parseDouble(nutrition['calories']);
+      final protein = _parseDouble(nutrition['proteinContent']);
+      final fat = _parseDouble(nutrition['fatContent']);
+      final carbs = _parseDouble(nutrition['carbohydrateContent']);
+      final sodium = _parseDouble(nutrition['sodiumContent']);
+      final fiber = _parseDouble(nutrition['fiberContent']);
+      
+      if (calories != null && calories > 0) {
+        return NutritionInfo(
+          calories: calories,
+          protein: protein ?? 0,
+          fat: fat ?? 0,
+          carbs: carbs ?? 0,
+          salt: sodium != null ? sodium * 2.54 / 1000 : 0, // ナトリウム→食塩相当量
+          fiber: fiber ?? 0,
+          source: 'JSON-LD商品データ',
+        );
+      }
+    }
+    
+    return null;
+  }
+  
+  /// OGP/メタデータから商品情報を抽出
+  FoodProductInfo? _extractFromOGP(Document document) {
+    String? name;
+    String? description;
+    String? imageUrl;
+    String? siteName;
+    
+    // OGPメタタグを検索
+    final metaTags = document.getElementsByTagName('meta');
+    
+    for (final meta in metaTags) {
+      final property = meta.attributes['property'] ?? meta.attributes['name'];
+      final content = meta.attributes['content'];
+      
+      if (property == null || content == null || content.isEmpty) continue;
+      
+      switch (property) {
+        case 'og:title':
+        case 'twitter:title':
+          name ??= content;
+          break;
+        case 'og:description':
+        case 'twitter:description':
+        case 'description':
+          description ??= content;
+          break;
+        case 'og:image':
+        case 'twitter:image':
+          imageUrl ??= content;
+          break;
+        case 'og:site_name':
+          siteName ??= content;
+          break;
+      }
+    }
+    
+    if (name != null && name.isNotEmpty) {
+      // HTMLから栄養情報も抽出
+      final nutrition = _nutritionExtractor.extractNutritionFromHtml(document);
+      
+      return FoodProductInfo(
+        name: name,
+        description: description,
+        imageUrl: imageUrl,
+        sourceSite: siteName,
+        nutrition: nutrition,
+        nutritionSource: nutrition != null ? nutrition.source : null,
+      );
+    }
+    
+    return null;
+  }
+  
+  /// HTMLパターンから商品情報を抽出
+  FoodProductInfo? _extractFromHTML(Document document) {
+    // タイトルタグから商品名を抽出
+    final titleElement = document.querySelector('title');
+    final name = titleElement?.text.trim();
+    
+    if (name == null || name.isEmpty) return null;
+    
+    // HTMLから栄養情報も抽出
+    final nutrition = _nutritionExtractor.extractNutritionFromHtml(document);
+    
+    return FoodProductInfo(
+      name: name,
+      nutrition: nutrition,
+      nutritionSource: nutrition != null ? nutrition.source : null,
+    );
+  }
+  
+  /// 文字列を数値に変換
+  double? _parseDouble(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) {
+      // 数値以外の文字を除去
+      final cleanValue = value.replaceAll(RegExp(r'[^\d.]'), '');
+      return double.tryParse(cleanValue);
+    }
+    return null;
+  }
+}
+
+/// 抽出された食品商品情報
+class FoodProductInfo {
+  final String name;
+  final String? productCode;
+  final String? brand;
+  final String? manufacturer;
+  final String? size;
+  final String? description;
+  final String? imageUrl;
+  final double? price;
+  final String? sourceUrl;
+  final String? sourceSite;
+  final String? category;
+  final NutritionInfo? nutrition;
+  final String? nutritionSource;
+  final List<String>? ingredients;
+  final List<String>? allergens;
+  final List<String>? tags;
+  
+  const FoodProductInfo({
+    required this.name,
+    this.productCode,
+    this.brand,
+    this.manufacturer,
+    this.size,
+    this.description,
+    this.imageUrl,
+    this.price,
+    this.sourceUrl,
+    this.sourceSite,
+    this.category,
+    this.nutrition,
+    this.nutritionSource,
+    this.ingredients,
+    this.allergens,
+    this.tags,
+  });
+  
+  /// コピーして一部の値を更新
+  FoodProductInfo copyWith({
+    String? name,
+    String? productCode,
+    String? brand,
+    String? manufacturer,
+    String? size,
+    String? description,
+    String? imageUrl,
+    double? price,
+    String? sourceUrl,
+    String? sourceSite,
+    String? category,
+    NutritionInfo? nutrition,
+    String? nutritionSource,
+    List<String>? ingredients,
+    List<String>? allergens,
+    List<String>? tags,
+  }) {
+    return FoodProductInfo(
+      name: name ?? this.name,
+      productCode: productCode ?? this.productCode,
+      brand: brand ?? this.brand,
+      manufacturer: manufacturer ?? this.manufacturer,
+      size: size ?? this.size,
+      description: description ?? this.description,
+      imageUrl: imageUrl ?? this.imageUrl,
+      price: price ?? this.price,
+      sourceUrl: sourceUrl ?? this.sourceUrl,
+      sourceSite: sourceSite ?? this.sourceSite,
+      category: category ?? this.category,
+      nutrition: nutrition ?? this.nutrition,
+      nutritionSource: nutritionSource ?? this.nutritionSource,
+      ingredients: ingredients ?? this.ingredients,
+      allergens: allergens ?? this.allergens,
+      tags: tags ?? this.tags,
+    );
+  }
+  
+  @override
+  String toString() {
+    return 'FoodProductInfo(name: $name, brand: $brand, price: $price, nutrition: $nutrition)';
+  }
+}

--- a/lib/core/services/nutrition_extraction_service.dart
+++ b/lib/core/services/nutrition_extraction_service.dart
@@ -1,0 +1,264 @@
+import 'package:html/dom.dart';
+
+/// レシピページから栄養情報を直接抽出するサービス
+class NutritionExtractionService {
+  
+  /// HTML文書から栄養表示情報を抽出
+  /// 材料分析より優先して使用される
+  NutritionInfo? extractNutritionFromHtml(Document document) {
+    print('デバッグ: HTML文書から栄養情報の抽出を開始');
+    
+    // 1. 構造化データ（JSON-LD）から栄養情報を抽出
+    final jsonLdNutrition = _extractFromJsonLD(document);
+    if (jsonLdNutrition != null) {
+      print('デバッグ: JSON-LDから栄養情報を抽出: ${jsonLdNutrition.calories}kcal');
+      return jsonLdNutrition;
+    }
+    
+    // 2. Microdataから栄養情報を抽出
+    final microdataNutrition = _extractFromMicrodata(document);
+    if (microdataNutrition != null) {
+      print('デバッグ: Microdataから栄養情報を抽出: ${microdataNutrition.calories}kcal');
+      return microdataNutrition;
+    }
+    
+    // 3. テキストパターンマッチングで栄養情報を抽出
+    final textNutrition = _extractFromTextPatterns(document);
+    if (textNutrition != null) {
+      print('デバッグ: テキストパターンから栄養情報を抽出: ${textNutrition.calories}kcal');
+      return textNutrition;
+    }
+    
+    // 4. テーブル構造から栄養情報を抽出
+    final tableNutrition = _extractFromTables(document);
+    if (tableNutrition != null) {
+      print('デバッグ: テーブルから栄養情報を抽出: ${tableNutrition.calories}kcal');
+      return tableNutrition;
+    }
+    
+    print('デバッグ: HTML文書から栄養情報は見つかりませんでした');
+    return null;
+  }
+  
+  /// JSON-LD構造化データから栄養情報を抽出
+  NutritionInfo? _extractFromJsonLD(Document document) {
+    final scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    
+    for (final script in scripts) {
+      try {
+        final jsonText = script.text;
+        if (jsonText.contains('Recipe') || jsonText.contains('nutrition')) {
+          // JSON-LD解析は複雑なため、簡単なパターンマッチングで対応
+          final caloriesMatch = RegExp(r'"calories"\s*:\s*"?(\d+\.?\d*)"?').firstMatch(jsonText);
+          final proteinMatch = RegExp(r'"proteinContent"\s*:\s*"?(\d+\.?\d*)"?').firstMatch(jsonText);
+          final fatMatch = RegExp(r'"fatContent"\s*:\s*"?(\d+\.?\d*)"?').firstMatch(jsonText);
+          final carbsMatch = RegExp(r'"carbohydrateContent"\s*:\s*"?(\d+\.?\d*)"?').firstMatch(jsonText);
+          
+          if (caloriesMatch != null) {
+            return NutritionInfo(
+              calories: double.tryParse(caloriesMatch.group(1)!) ?? 0,
+              protein: proteinMatch != null ? (double.tryParse(proteinMatch.group(1)!) ?? 0) : 0,
+              fat: fatMatch != null ? (double.tryParse(fatMatch.group(1)!) ?? 0) : 0,
+              carbs: carbsMatch != null ? (double.tryParse(carbsMatch.group(1)!) ?? 0) : 0,
+              source: 'JSON-LD',
+            );
+          }
+        }
+      } catch (e) {
+        print('JSON-LD解析エラー: $e');
+        continue;
+      }
+    }
+    
+    return null;
+  }
+  
+  /// Microdataから栄養情報を抽出
+  NutritionInfo? _extractFromMicrodata(Document document) {
+    // Recipe microdataを探す
+    final recipeElements = document.querySelectorAll('[itemtype*="Recipe"]');
+    
+    for (final recipe in recipeElements) {
+      final nutritionElement = recipe.querySelector('[itemtype*="NutritionInformation"]');
+      if (nutritionElement != null) {
+        final calories = _extractMicrodataProperty(nutritionElement, 'calories');
+        final protein = _extractMicrodataProperty(nutritionElement, 'proteinContent');
+        final fat = _extractMicrodataProperty(nutritionElement, 'fatContent');
+        final carbs = _extractMicrodataProperty(nutritionElement, 'carbohydrateContent');
+        
+        if (calories > 0) {
+          return NutritionInfo(
+            calories: calories,
+            protein: protein,
+            fat: fat,
+            carbs: carbs,
+            source: 'Microdata',
+          );
+        }
+      }
+    }
+    
+    return null;
+  }
+  
+  /// Microdataプロパティを抽出
+  double _extractMicrodataProperty(Element element, String property) {
+    final propertyElement = element.querySelector('[itemprop="$property"]');
+    if (propertyElement != null) {
+      final content = propertyElement.attributes['content'] ?? propertyElement.text;
+      return double.tryParse(content.replaceAll(RegExp(r'[^\d.]'), '')) ?? 0;
+    }
+    return 0;
+  }
+  
+  /// テキストパターンから栄養情報を抽出
+  NutritionInfo? _extractFromTextPatterns(Document document) {
+    final bodyText = document.body?.text ?? '';
+    
+    // 日本語の栄養表示パターン
+    final patterns = [
+      // カロリー・エネルギー
+      RegExp(r'(?:カロリー|エネルギー|kcal)[：:\s]*(\d+\.?\d*)(?:\s*kcal)?', caseSensitive: false),
+      // タンパク質
+      RegExp(r'(?:たんぱく質|タンパク質|蛋白質|protein)[：:\s]*(\d+\.?\d*)(?:\s*g)?', caseSensitive: false),
+      // 脂質
+      RegExp(r'(?:脂質|脂肪|fat)[：:\s]*(\d+\.?\d*)(?:\s*g)?', caseSensitive: false),
+      // 炭水化物
+      RegExp(r'(?:炭水化物|carbohydrate)[：:\s]*(\d+\.?\d*)(?:\s*g)?', caseSensitive: false),
+      // 食塩相当量・塩分
+      RegExp(r'(?:食塩相当量|塩分|sodium)[：:\s]*(\d+\.?\d*)(?:\s*g)?', caseSensitive: false),
+    ];
+    
+    double? calories;
+    double protein = 0;
+    double fat = 0;
+    double carbs = 0;
+    double salt = 0;
+    
+    // カロリー抽出
+    final caloriesMatch = patterns[0].firstMatch(bodyText);
+    if (caloriesMatch != null) {
+      calories = double.tryParse(caloriesMatch.group(1)!);
+    }
+    
+    // その他の栄養素
+    final proteinMatch = patterns[1].firstMatch(bodyText);
+    if (proteinMatch != null) {
+      protein = double.tryParse(proteinMatch.group(1)!) ?? 0;
+    }
+    
+    final fatMatch = patterns[2].firstMatch(bodyText);
+    if (fatMatch != null) {
+      fat = double.tryParse(fatMatch.group(1)!) ?? 0;
+    }
+    
+    final carbsMatch = patterns[3].firstMatch(bodyText);
+    if (carbsMatch != null) {
+      carbs = double.tryParse(carbsMatch.group(1)!) ?? 0;
+    }
+    
+    final saltMatch = patterns[4].firstMatch(bodyText);
+    if (saltMatch != null) {
+      salt = double.tryParse(saltMatch.group(1)!) ?? 0;
+    }
+    
+    if (calories != null && calories > 0) {
+      return NutritionInfo(
+        calories: calories,
+        protein: protein,
+        fat: fat,
+        carbs: carbs,
+        salt: salt,
+        source: 'テキストパターン',
+      );
+    }
+    
+    return null;
+  }
+  
+  /// テーブル構造から栄養情報を抽出
+  NutritionInfo? _extractFromTables(Document document) {
+    final tables = document.querySelectorAll('table');
+    
+    for (final table in tables) {
+      // 栄養情報テーブルの特徴的なキーワードを探す
+      final tableText = table.text.toLowerCase();
+      if (tableText.contains('栄養') || tableText.contains('カロリー') || 
+          tableText.contains('エネルギー') || tableText.contains('nutrition')) {
+        
+        final rows = table.querySelectorAll('tr');
+        
+        double? calories;
+        double protein = 0;
+        double fat = 0;
+        double carbs = 0;
+        double salt = 0;
+        
+        for (final row in rows) {
+          final cells = row.querySelectorAll('td, th');
+          if (cells.length >= 2) {
+            final label = cells[0].text.toLowerCase();
+            final valueText = cells[1].text;
+            final value = double.tryParse(valueText.replaceAll(RegExp(r'[^\d.]'), '')) ?? 0;
+            
+            if (label.contains('カロリー') || label.contains('エネルギー') || label.contains('kcal')) {
+              calories = value;
+            } else if (label.contains('たんぱく質') || label.contains('タンパク質') || label.contains('蛋白質')) {
+              protein = value;
+            } else if (label.contains('脂質') || label.contains('脂肪')) {
+              fat = value;
+            } else if (label.contains('炭水化物')) {
+              carbs = value;
+            } else if (label.contains('食塩相当量') || label.contains('塩分')) {
+              salt = value;
+            }
+          }
+        }
+        
+        if (calories != null && calories > 0) {
+          return NutritionInfo(
+            calories: calories,
+            protein: protein,
+            fat: fat,
+            carbs: carbs,
+            salt: salt,
+            source: 'テーブル',
+          );
+        }
+      }
+    }
+    
+    return null;
+  }
+}
+
+/// 抽出された栄養情報
+class NutritionInfo {
+  final double calories;
+  final double protein;
+  final double fat;
+  final double carbs;
+  final double salt;
+  final double fiber;
+  final double vitaminC;
+  final String source; // 抽出元の情報
+  
+  const NutritionInfo({
+    required this.calories,
+    this.protein = 0,
+    this.fat = 0,
+    this.carbs = 0,
+    this.salt = 0,
+    this.fiber = 0,
+    this.vitaminC = 0,
+    required this.source,
+  });
+  
+  /// 栄養情報が有効かどうか
+  bool get isValid => calories > 0;
+  
+  @override
+  String toString() {
+    return 'NutritionInfo(calories: $calories, protein: $protein, fat: $fat, carbs: $carbs, source: $source)';
+  }
+}

--- a/lib/data/datasources/app_database.dart
+++ b/lib/data/datasources/app_database.dart
@@ -40,7 +40,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
   
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -65,6 +65,18 @@ class AppDatabase extends _$AppDatabase {
         
         // JapaneseFoodCompositionTableを作成
         await m.createTable(japaneseFoodCompositionTable);
+      }
+      
+      if (from < 3) {
+        // バージョン2から3へのマイグレーション
+        // ExternalRecipeTableに食品商品用フィールドを追加
+        await m.addColumn(externalRecipeTable, externalRecipeTable.itemType);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.productCode);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.brand);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.size);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.price);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.category);
+        await m.addColumn(externalRecipeTable, externalRecipeTable.nutritionSource);
       }
     },
   );

--- a/lib/data/datasources/app_database.g.dart
+++ b/lib/data/datasources/app_database.g.dart
@@ -550,6 +550,16 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
       type: DriftSqlType.string,
       requiredDuringInsert: true,
       defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _itemTypeMeta =
+      const VerificationMeta('itemType');
+  @override
+  late final GeneratedColumn<String> itemType = GeneratedColumn<String>(
+      'item_type', aliasedName, false,
+      additionalChecks:
+          GeneratedColumn.checkTextLength(minTextLength: 1, maxTextLength: 20),
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('recipe'));
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
   late final GeneratedColumn<String> title = GeneratedColumn<String>(
@@ -595,6 +605,39 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
   @override
   late final GeneratedColumn<String> memo = GeneratedColumn<String>(
       'memo', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _productCodeMeta =
+      const VerificationMeta('productCode');
+  @override
+  late final GeneratedColumn<String> productCode = GeneratedColumn<String>(
+      'product_code', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _brandMeta = const VerificationMeta('brand');
+  @override
+  late final GeneratedColumn<String> brand = GeneratedColumn<String>(
+      'brand', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _sizeMeta = const VerificationMeta('size');
+  @override
+  late final GeneratedColumn<String> size = GeneratedColumn<String>(
+      'size', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _priceMeta = const VerificationMeta('price');
+  @override
+  late final GeneratedColumn<double> price = GeneratedColumn<double>(
+      'price', aliasedName, true,
+      type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _categoryMeta =
+      const VerificationMeta('category');
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+      'category', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _nutritionSourceMeta =
+      const VerificationMeta('nutritionSource');
+  @override
+  late final GeneratedColumn<String> nutritionSource = GeneratedColumn<String>(
+      'nutrition_source', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _ingredientsJsonMeta =
       const VerificationMeta('ingredientsJson');
@@ -692,6 +735,7 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
   List<GeneratedColumn> get $columns => [
         id,
         url,
+        itemType,
         title,
         description,
         imageUrl,
@@ -699,6 +743,12 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
         isFavorite,
         tags,
         memo,
+        productCode,
+        brand,
+        size,
+        price,
+        category,
+        nutritionSource,
         ingredientsJson,
         ingredientsRawText,
         calories,
@@ -734,6 +784,10 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
     } else if (isInserting) {
       context.missing(_urlMeta);
     }
+    if (data.containsKey('item_type')) {
+      context.handle(_itemTypeMeta,
+          itemType.isAcceptableOrUnknown(data['item_type']!, _itemTypeMeta));
+    }
     if (data.containsKey('title')) {
       context.handle(
           _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
@@ -767,6 +821,34 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
     if (data.containsKey('memo')) {
       context.handle(
           _memoMeta, memo.isAcceptableOrUnknown(data['memo']!, _memoMeta));
+    }
+    if (data.containsKey('product_code')) {
+      context.handle(
+          _productCodeMeta,
+          productCode.isAcceptableOrUnknown(
+              data['product_code']!, _productCodeMeta));
+    }
+    if (data.containsKey('brand')) {
+      context.handle(
+          _brandMeta, brand.isAcceptableOrUnknown(data['brand']!, _brandMeta));
+    }
+    if (data.containsKey('size')) {
+      context.handle(
+          _sizeMeta, size.isAcceptableOrUnknown(data['size']!, _sizeMeta));
+    }
+    if (data.containsKey('price')) {
+      context.handle(
+          _priceMeta, price.isAcceptableOrUnknown(data['price']!, _priceMeta));
+    }
+    if (data.containsKey('category')) {
+      context.handle(_categoryMeta,
+          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
+    }
+    if (data.containsKey('nutrition_source')) {
+      context.handle(
+          _nutritionSourceMeta,
+          nutritionSource.isAcceptableOrUnknown(
+              data['nutrition_source']!, _nutritionSourceMeta));
     }
     if (data.containsKey('ingredients_json')) {
       context.handle(
@@ -849,6 +931,8 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
       url: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}url'])!,
+      itemType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}item_type'])!,
       title: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
       description: attachedDatabase.typeMapping
@@ -863,6 +947,18 @@ class $ExternalRecipeTableTable extends ExternalRecipeTable
           .read(DriftSqlType.string, data['${effectivePrefix}tags']),
       memo: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}memo']),
+      productCode: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}product_code']),
+      brand: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}brand']),
+      size: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}size']),
+      price: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}price']),
+      category: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}category']),
+      nutritionSource: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}nutrition_source']),
       ingredientsJson: attachedDatabase.typeMapping.read(
           DriftSqlType.string, data['${effectivePrefix}ingredients_json']),
       ingredientsRawText: attachedDatabase.typeMapping.read(
@@ -909,6 +1005,9 @@ class ExternalRecipeTableData extends DataClass
   /// レシピURL
   final String url;
 
+  /// アイテムタイプ（'recipe' | 'food_product'）
+  final String itemType;
+
   /// タイトル（OGPから取得）
   final String title;
 
@@ -930,6 +1029,26 @@ class ExternalRecipeTableData extends DataClass
   /// メモ
   final String? memo;
 
+  /// === 食品商品専用フィールド ===
+  /// 商品コード（JANコード等）
+  final String? productCode;
+
+  /// ブランド名
+  final String? brand;
+
+  /// 商品サイズ・容量
+  final String? size;
+
+  /// 商品価格（円）
+  final double? price;
+
+  /// カテゴリ
+  final String? category;
+
+  /// 栄養情報の情報源
+  final String? nutritionSource;
+
+  /// === 共通フィールド ===
   /// 材料情報（JSON形式）
   final String? ingredientsJson;
 
@@ -974,6 +1093,7 @@ class ExternalRecipeTableData extends DataClass
   const ExternalRecipeTableData(
       {required this.id,
       required this.url,
+      required this.itemType,
       required this.title,
       this.description,
       this.imageUrl,
@@ -981,6 +1101,12 @@ class ExternalRecipeTableData extends DataClass
       required this.isFavorite,
       this.tags,
       this.memo,
+      this.productCode,
+      this.brand,
+      this.size,
+      this.price,
+      this.category,
+      this.nutritionSource,
       this.ingredientsJson,
       this.ingredientsRawText,
       this.calories,
@@ -1000,6 +1126,7 @@ class ExternalRecipeTableData extends DataClass
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     map['url'] = Variable<String>(url);
+    map['item_type'] = Variable<String>(itemType);
     map['title'] = Variable<String>(title);
     if (!nullToAbsent || description != null) {
       map['description'] = Variable<String>(description);
@@ -1016,6 +1143,24 @@ class ExternalRecipeTableData extends DataClass
     }
     if (!nullToAbsent || memo != null) {
       map['memo'] = Variable<String>(memo);
+    }
+    if (!nullToAbsent || productCode != null) {
+      map['product_code'] = Variable<String>(productCode);
+    }
+    if (!nullToAbsent || brand != null) {
+      map['brand'] = Variable<String>(brand);
+    }
+    if (!nullToAbsent || size != null) {
+      map['size'] = Variable<String>(size);
+    }
+    if (!nullToAbsent || price != null) {
+      map['price'] = Variable<double>(price);
+    }
+    if (!nullToAbsent || category != null) {
+      map['category'] = Variable<String>(category);
+    }
+    if (!nullToAbsent || nutritionSource != null) {
+      map['nutrition_source'] = Variable<String>(nutritionSource);
     }
     if (!nullToAbsent || ingredientsJson != null) {
       map['ingredients_json'] = Variable<String>(ingredientsJson);
@@ -1059,6 +1204,7 @@ class ExternalRecipeTableData extends DataClass
     return ExternalRecipeTableCompanion(
       id: Value(id),
       url: Value(url),
+      itemType: Value(itemType),
       title: Value(title),
       description: description == null && nullToAbsent
           ? const Value.absent()
@@ -1072,6 +1218,20 @@ class ExternalRecipeTableData extends DataClass
       isFavorite: Value(isFavorite),
       tags: tags == null && nullToAbsent ? const Value.absent() : Value(tags),
       memo: memo == null && nullToAbsent ? const Value.absent() : Value(memo),
+      productCode: productCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(productCode),
+      brand:
+          brand == null && nullToAbsent ? const Value.absent() : Value(brand),
+      size: size == null && nullToAbsent ? const Value.absent() : Value(size),
+      price:
+          price == null && nullToAbsent ? const Value.absent() : Value(price),
+      category: category == null && nullToAbsent
+          ? const Value.absent()
+          : Value(category),
+      nutritionSource: nutritionSource == null && nullToAbsent
+          ? const Value.absent()
+          : Value(nutritionSource),
       ingredientsJson: ingredientsJson == null && nullToAbsent
           ? const Value.absent()
           : Value(ingredientsJson),
@@ -1110,6 +1270,7 @@ class ExternalRecipeTableData extends DataClass
     return ExternalRecipeTableData(
       id: serializer.fromJson<int>(json['id']),
       url: serializer.fromJson<String>(json['url']),
+      itemType: serializer.fromJson<String>(json['itemType']),
       title: serializer.fromJson<String>(json['title']),
       description: serializer.fromJson<String?>(json['description']),
       imageUrl: serializer.fromJson<String?>(json['imageUrl']),
@@ -1117,6 +1278,12 @@ class ExternalRecipeTableData extends DataClass
       isFavorite: serializer.fromJson<bool>(json['isFavorite']),
       tags: serializer.fromJson<String?>(json['tags']),
       memo: serializer.fromJson<String?>(json['memo']),
+      productCode: serializer.fromJson<String?>(json['productCode']),
+      brand: serializer.fromJson<String?>(json['brand']),
+      size: serializer.fromJson<String?>(json['size']),
+      price: serializer.fromJson<double?>(json['price']),
+      category: serializer.fromJson<String?>(json['category']),
+      nutritionSource: serializer.fromJson<String?>(json['nutritionSource']),
       ingredientsJson: serializer.fromJson<String?>(json['ingredientsJson']),
       ingredientsRawText:
           serializer.fromJson<String?>(json['ingredientsRawText']),
@@ -1141,6 +1308,7 @@ class ExternalRecipeTableData extends DataClass
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
       'url': serializer.toJson<String>(url),
+      'itemType': serializer.toJson<String>(itemType),
       'title': serializer.toJson<String>(title),
       'description': serializer.toJson<String?>(description),
       'imageUrl': serializer.toJson<String?>(imageUrl),
@@ -1148,6 +1316,12 @@ class ExternalRecipeTableData extends DataClass
       'isFavorite': serializer.toJson<bool>(isFavorite),
       'tags': serializer.toJson<String?>(tags),
       'memo': serializer.toJson<String?>(memo),
+      'productCode': serializer.toJson<String?>(productCode),
+      'brand': serializer.toJson<String?>(brand),
+      'size': serializer.toJson<String?>(size),
+      'price': serializer.toJson<double?>(price),
+      'category': serializer.toJson<String?>(category),
+      'nutritionSource': serializer.toJson<String?>(nutritionSource),
       'ingredientsJson': serializer.toJson<String?>(ingredientsJson),
       'ingredientsRawText': serializer.toJson<String?>(ingredientsRawText),
       'calories': serializer.toJson<double?>(calories),
@@ -1169,6 +1343,7 @@ class ExternalRecipeTableData extends DataClass
   ExternalRecipeTableData copyWith(
           {int? id,
           String? url,
+          String? itemType,
           String? title,
           Value<String?> description = const Value.absent(),
           Value<String?> imageUrl = const Value.absent(),
@@ -1176,6 +1351,12 @@ class ExternalRecipeTableData extends DataClass
           bool? isFavorite,
           Value<String?> tags = const Value.absent(),
           Value<String?> memo = const Value.absent(),
+          Value<String?> productCode = const Value.absent(),
+          Value<String?> brand = const Value.absent(),
+          Value<String?> size = const Value.absent(),
+          Value<double?> price = const Value.absent(),
+          Value<String?> category = const Value.absent(),
+          Value<String?> nutritionSource = const Value.absent(),
           Value<String?> ingredientsJson = const Value.absent(),
           Value<String?> ingredientsRawText = const Value.absent(),
           Value<double?> calories = const Value.absent(),
@@ -1193,6 +1374,7 @@ class ExternalRecipeTableData extends DataClass
       ExternalRecipeTableData(
         id: id ?? this.id,
         url: url ?? this.url,
+        itemType: itemType ?? this.itemType,
         title: title ?? this.title,
         description: description.present ? description.value : this.description,
         imageUrl: imageUrl.present ? imageUrl.value : this.imageUrl,
@@ -1200,6 +1382,14 @@ class ExternalRecipeTableData extends DataClass
         isFavorite: isFavorite ?? this.isFavorite,
         tags: tags.present ? tags.value : this.tags,
         memo: memo.present ? memo.value : this.memo,
+        productCode: productCode.present ? productCode.value : this.productCode,
+        brand: brand.present ? brand.value : this.brand,
+        size: size.present ? size.value : this.size,
+        price: price.present ? price.value : this.price,
+        category: category.present ? category.value : this.category,
+        nutritionSource: nutritionSource.present
+            ? nutritionSource.value
+            : this.nutritionSource,
         ingredientsJson: ingredientsJson.present
             ? ingredientsJson.value
             : this.ingredientsJson,
@@ -1226,6 +1416,7 @@ class ExternalRecipeTableData extends DataClass
     return ExternalRecipeTableData(
       id: data.id.present ? data.id.value : this.id,
       url: data.url.present ? data.url.value : this.url,
+      itemType: data.itemType.present ? data.itemType.value : this.itemType,
       title: data.title.present ? data.title.value : this.title,
       description:
           data.description.present ? data.description.value : this.description,
@@ -1235,6 +1426,15 @@ class ExternalRecipeTableData extends DataClass
           data.isFavorite.present ? data.isFavorite.value : this.isFavorite,
       tags: data.tags.present ? data.tags.value : this.tags,
       memo: data.memo.present ? data.memo.value : this.memo,
+      productCode:
+          data.productCode.present ? data.productCode.value : this.productCode,
+      brand: data.brand.present ? data.brand.value : this.brand,
+      size: data.size.present ? data.size.value : this.size,
+      price: data.price.present ? data.price.value : this.price,
+      category: data.category.present ? data.category.value : this.category,
+      nutritionSource: data.nutritionSource.present
+          ? data.nutritionSource.value
+          : this.nutritionSource,
       ingredientsJson: data.ingredientsJson.present
           ? data.ingredientsJson.value
           : this.ingredientsJson,
@@ -1267,6 +1467,7 @@ class ExternalRecipeTableData extends DataClass
     return (StringBuffer('ExternalRecipeTableData(')
           ..write('id: $id, ')
           ..write('url: $url, ')
+          ..write('itemType: $itemType, ')
           ..write('title: $title, ')
           ..write('description: $description, ')
           ..write('imageUrl: $imageUrl, ')
@@ -1274,6 +1475,12 @@ class ExternalRecipeTableData extends DataClass
           ..write('isFavorite: $isFavorite, ')
           ..write('tags: $tags, ')
           ..write('memo: $memo, ')
+          ..write('productCode: $productCode, ')
+          ..write('brand: $brand, ')
+          ..write('size: $size, ')
+          ..write('price: $price, ')
+          ..write('category: $category, ')
+          ..write('nutritionSource: $nutritionSource, ')
           ..write('ingredientsJson: $ingredientsJson, ')
           ..write('ingredientsRawText: $ingredientsRawText, ')
           ..write('calories: $calories, ')
@@ -1296,6 +1503,7 @@ class ExternalRecipeTableData extends DataClass
   int get hashCode => Object.hashAll([
         id,
         url,
+        itemType,
         title,
         description,
         imageUrl,
@@ -1303,6 +1511,12 @@ class ExternalRecipeTableData extends DataClass
         isFavorite,
         tags,
         memo,
+        productCode,
+        brand,
+        size,
+        price,
+        category,
+        nutritionSource,
         ingredientsJson,
         ingredientsRawText,
         calories,
@@ -1324,6 +1538,7 @@ class ExternalRecipeTableData extends DataClass
       (other is ExternalRecipeTableData &&
           other.id == this.id &&
           other.url == this.url &&
+          other.itemType == this.itemType &&
           other.title == this.title &&
           other.description == this.description &&
           other.imageUrl == this.imageUrl &&
@@ -1331,6 +1546,12 @@ class ExternalRecipeTableData extends DataClass
           other.isFavorite == this.isFavorite &&
           other.tags == this.tags &&
           other.memo == this.memo &&
+          other.productCode == this.productCode &&
+          other.brand == this.brand &&
+          other.size == this.size &&
+          other.price == this.price &&
+          other.category == this.category &&
+          other.nutritionSource == this.nutritionSource &&
           other.ingredientsJson == this.ingredientsJson &&
           other.ingredientsRawText == this.ingredientsRawText &&
           other.calories == this.calories &&
@@ -1351,6 +1572,7 @@ class ExternalRecipeTableCompanion
     extends UpdateCompanion<ExternalRecipeTableData> {
   final Value<int> id;
   final Value<String> url;
+  final Value<String> itemType;
   final Value<String> title;
   final Value<String?> description;
   final Value<String?> imageUrl;
@@ -1358,6 +1580,12 @@ class ExternalRecipeTableCompanion
   final Value<bool> isFavorite;
   final Value<String?> tags;
   final Value<String?> memo;
+  final Value<String?> productCode;
+  final Value<String?> brand;
+  final Value<String?> size;
+  final Value<double?> price;
+  final Value<String?> category;
+  final Value<String?> nutritionSource;
   final Value<String?> ingredientsJson;
   final Value<String?> ingredientsRawText;
   final Value<double?> calories;
@@ -1375,6 +1603,7 @@ class ExternalRecipeTableCompanion
   const ExternalRecipeTableCompanion({
     this.id = const Value.absent(),
     this.url = const Value.absent(),
+    this.itemType = const Value.absent(),
     this.title = const Value.absent(),
     this.description = const Value.absent(),
     this.imageUrl = const Value.absent(),
@@ -1382,6 +1611,12 @@ class ExternalRecipeTableCompanion
     this.isFavorite = const Value.absent(),
     this.tags = const Value.absent(),
     this.memo = const Value.absent(),
+    this.productCode = const Value.absent(),
+    this.brand = const Value.absent(),
+    this.size = const Value.absent(),
+    this.price = const Value.absent(),
+    this.category = const Value.absent(),
+    this.nutritionSource = const Value.absent(),
     this.ingredientsJson = const Value.absent(),
     this.ingredientsRawText = const Value.absent(),
     this.calories = const Value.absent(),
@@ -1400,6 +1635,7 @@ class ExternalRecipeTableCompanion
   ExternalRecipeTableCompanion.insert({
     this.id = const Value.absent(),
     required String url,
+    this.itemType = const Value.absent(),
     required String title,
     this.description = const Value.absent(),
     this.imageUrl = const Value.absent(),
@@ -1407,6 +1643,12 @@ class ExternalRecipeTableCompanion
     this.isFavorite = const Value.absent(),
     this.tags = const Value.absent(),
     this.memo = const Value.absent(),
+    this.productCode = const Value.absent(),
+    this.brand = const Value.absent(),
+    this.size = const Value.absent(),
+    this.price = const Value.absent(),
+    this.category = const Value.absent(),
+    this.nutritionSource = const Value.absent(),
     this.ingredientsJson = const Value.absent(),
     this.ingredientsRawText = const Value.absent(),
     this.calories = const Value.absent(),
@@ -1426,6 +1668,7 @@ class ExternalRecipeTableCompanion
   static Insertable<ExternalRecipeTableData> custom({
     Expression<int>? id,
     Expression<String>? url,
+    Expression<String>? itemType,
     Expression<String>? title,
     Expression<String>? description,
     Expression<String>? imageUrl,
@@ -1433,6 +1676,12 @@ class ExternalRecipeTableCompanion
     Expression<bool>? isFavorite,
     Expression<String>? tags,
     Expression<String>? memo,
+    Expression<String>? productCode,
+    Expression<String>? brand,
+    Expression<String>? size,
+    Expression<double>? price,
+    Expression<String>? category,
+    Expression<String>? nutritionSource,
     Expression<String>? ingredientsJson,
     Expression<String>? ingredientsRawText,
     Expression<double>? calories,
@@ -1451,6 +1700,7 @@ class ExternalRecipeTableCompanion
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (url != null) 'url': url,
+      if (itemType != null) 'item_type': itemType,
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (imageUrl != null) 'image_url': imageUrl,
@@ -1458,6 +1708,12 @@ class ExternalRecipeTableCompanion
       if (isFavorite != null) 'is_favorite': isFavorite,
       if (tags != null) 'tags': tags,
       if (memo != null) 'memo': memo,
+      if (productCode != null) 'product_code': productCode,
+      if (brand != null) 'brand': brand,
+      if (size != null) 'size': size,
+      if (price != null) 'price': price,
+      if (category != null) 'category': category,
+      if (nutritionSource != null) 'nutrition_source': nutritionSource,
       if (ingredientsJson != null) 'ingredients_json': ingredientsJson,
       if (ingredientsRawText != null)
         'ingredients_raw_text': ingredientsRawText,
@@ -1480,6 +1736,7 @@ class ExternalRecipeTableCompanion
   ExternalRecipeTableCompanion copyWith(
       {Value<int>? id,
       Value<String>? url,
+      Value<String>? itemType,
       Value<String>? title,
       Value<String?>? description,
       Value<String?>? imageUrl,
@@ -1487,6 +1744,12 @@ class ExternalRecipeTableCompanion
       Value<bool>? isFavorite,
       Value<String?>? tags,
       Value<String?>? memo,
+      Value<String?>? productCode,
+      Value<String?>? brand,
+      Value<String?>? size,
+      Value<double?>? price,
+      Value<String?>? category,
+      Value<String?>? nutritionSource,
       Value<String?>? ingredientsJson,
       Value<String?>? ingredientsRawText,
       Value<double?>? calories,
@@ -1504,6 +1767,7 @@ class ExternalRecipeTableCompanion
     return ExternalRecipeTableCompanion(
       id: id ?? this.id,
       url: url ?? this.url,
+      itemType: itemType ?? this.itemType,
       title: title ?? this.title,
       description: description ?? this.description,
       imageUrl: imageUrl ?? this.imageUrl,
@@ -1511,6 +1775,12 @@ class ExternalRecipeTableCompanion
       isFavorite: isFavorite ?? this.isFavorite,
       tags: tags ?? this.tags,
       memo: memo ?? this.memo,
+      productCode: productCode ?? this.productCode,
+      brand: brand ?? this.brand,
+      size: size ?? this.size,
+      price: price ?? this.price,
+      category: category ?? this.category,
+      nutritionSource: nutritionSource ?? this.nutritionSource,
       ingredientsJson: ingredientsJson ?? this.ingredientsJson,
       ingredientsRawText: ingredientsRawText ?? this.ingredientsRawText,
       calories: calories ?? this.calories,
@@ -1538,6 +1808,9 @@ class ExternalRecipeTableCompanion
     if (url.present) {
       map['url'] = Variable<String>(url.value);
     }
+    if (itemType.present) {
+      map['item_type'] = Variable<String>(itemType.value);
+    }
     if (title.present) {
       map['title'] = Variable<String>(title.value);
     }
@@ -1558,6 +1831,24 @@ class ExternalRecipeTableCompanion
     }
     if (memo.present) {
       map['memo'] = Variable<String>(memo.value);
+    }
+    if (productCode.present) {
+      map['product_code'] = Variable<String>(productCode.value);
+    }
+    if (brand.present) {
+      map['brand'] = Variable<String>(brand.value);
+    }
+    if (size.present) {
+      map['size'] = Variable<String>(size.value);
+    }
+    if (price.present) {
+      map['price'] = Variable<double>(price.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (nutritionSource.present) {
+      map['nutrition_source'] = Variable<String>(nutritionSource.value);
     }
     if (ingredientsJson.present) {
       map['ingredients_json'] = Variable<String>(ingredientsJson.value);
@@ -1610,6 +1901,7 @@ class ExternalRecipeTableCompanion
     return (StringBuffer('ExternalRecipeTableCompanion(')
           ..write('id: $id, ')
           ..write('url: $url, ')
+          ..write('itemType: $itemType, ')
           ..write('title: $title, ')
           ..write('description: $description, ')
           ..write('imageUrl: $imageUrl, ')
@@ -1617,6 +1909,12 @@ class ExternalRecipeTableCompanion
           ..write('isFavorite: $isFavorite, ')
           ..write('tags: $tags, ')
           ..write('memo: $memo, ')
+          ..write('productCode: $productCode, ')
+          ..write('brand: $brand, ')
+          ..write('size: $size, ')
+          ..write('price: $price, ')
+          ..write('category: $category, ')
+          ..write('nutritionSource: $nutritionSource, ')
           ..write('ingredientsJson: $ingredientsJson, ')
           ..write('ingredientsRawText: $ingredientsRawText, ')
           ..write('calories: $calories, ')
@@ -6085,6 +6383,7 @@ typedef $$ExternalRecipeTableTableCreateCompanionBuilder
     = ExternalRecipeTableCompanion Function({
   Value<int> id,
   required String url,
+  Value<String> itemType,
   required String title,
   Value<String?> description,
   Value<String?> imageUrl,
@@ -6092,6 +6391,12 @@ typedef $$ExternalRecipeTableTableCreateCompanionBuilder
   Value<bool> isFavorite,
   Value<String?> tags,
   Value<String?> memo,
+  Value<String?> productCode,
+  Value<String?> brand,
+  Value<String?> size,
+  Value<double?> price,
+  Value<String?> category,
+  Value<String?> nutritionSource,
   Value<String?> ingredientsJson,
   Value<String?> ingredientsRawText,
   Value<double?> calories,
@@ -6111,6 +6416,7 @@ typedef $$ExternalRecipeTableTableUpdateCompanionBuilder
     = ExternalRecipeTableCompanion Function({
   Value<int> id,
   Value<String> url,
+  Value<String> itemType,
   Value<String> title,
   Value<String?> description,
   Value<String?> imageUrl,
@@ -6118,6 +6424,12 @@ typedef $$ExternalRecipeTableTableUpdateCompanionBuilder
   Value<bool> isFavorite,
   Value<String?> tags,
   Value<String?> memo,
+  Value<String?> productCode,
+  Value<String?> brand,
+  Value<String?> size,
+  Value<double?> price,
+  Value<String?> category,
+  Value<String?> nutritionSource,
   Value<String?> ingredientsJson,
   Value<String?> ingredientsRawText,
   Value<double?> calories,
@@ -6171,6 +6483,9 @@ class $$ExternalRecipeTableTableFilterComposer
   ColumnFilters<String> get url => $composableBuilder(
       column: $table.url, builder: (column) => ColumnFilters(column));
 
+  ColumnFilters<String> get itemType => $composableBuilder(
+      column: $table.itemType, builder: (column) => ColumnFilters(column));
+
   ColumnFilters<String> get title => $composableBuilder(
       column: $table.title, builder: (column) => ColumnFilters(column));
 
@@ -6191,6 +6506,25 @@ class $$ExternalRecipeTableTableFilterComposer
 
   ColumnFilters<String> get memo => $composableBuilder(
       column: $table.memo, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get productCode => $composableBuilder(
+      column: $table.productCode, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get brand => $composableBuilder(
+      column: $table.brand, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get size => $composableBuilder(
+      column: $table.size, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<double> get price => $composableBuilder(
+      column: $table.price, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get category => $composableBuilder(
+      column: $table.category, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get nutritionSource => $composableBuilder(
+      column: $table.nutritionSource,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get ingredientsJson => $composableBuilder(
       column: $table.ingredientsJson,
@@ -6275,6 +6609,9 @@ class $$ExternalRecipeTableTableOrderingComposer
   ColumnOrderings<String> get url => $composableBuilder(
       column: $table.url, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get itemType => $composableBuilder(
+      column: $table.itemType, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get title => $composableBuilder(
       column: $table.title, builder: (column) => ColumnOrderings(column));
 
@@ -6295,6 +6632,25 @@ class $$ExternalRecipeTableTableOrderingComposer
 
   ColumnOrderings<String> get memo => $composableBuilder(
       column: $table.memo, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get productCode => $composableBuilder(
+      column: $table.productCode, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get brand => $composableBuilder(
+      column: $table.brand, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get size => $composableBuilder(
+      column: $table.size, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<double> get price => $composableBuilder(
+      column: $table.price, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get category => $composableBuilder(
+      column: $table.category, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get nutritionSource => $composableBuilder(
+      column: $table.nutritionSource,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get ingredientsJson => $composableBuilder(
       column: $table.ingredientsJson,
@@ -6359,6 +6715,9 @@ class $$ExternalRecipeTableTableAnnotationComposer
   GeneratedColumn<String> get url =>
       $composableBuilder(column: $table.url, builder: (column) => column);
 
+  GeneratedColumn<String> get itemType =>
+      $composableBuilder(column: $table.itemType, builder: (column) => column);
+
   GeneratedColumn<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => column);
 
@@ -6379,6 +6738,24 @@ class $$ExternalRecipeTableTableAnnotationComposer
 
   GeneratedColumn<String> get memo =>
       $composableBuilder(column: $table.memo, builder: (column) => column);
+
+  GeneratedColumn<String> get productCode => $composableBuilder(
+      column: $table.productCode, builder: (column) => column);
+
+  GeneratedColumn<String> get brand =>
+      $composableBuilder(column: $table.brand, builder: (column) => column);
+
+  GeneratedColumn<String> get size =>
+      $composableBuilder(column: $table.size, builder: (column) => column);
+
+  GeneratedColumn<double> get price =>
+      $composableBuilder(column: $table.price, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get nutritionSource => $composableBuilder(
+      column: $table.nutritionSource, builder: (column) => column);
 
   GeneratedColumn<String> get ingredientsJson => $composableBuilder(
       column: $table.ingredientsJson, builder: (column) => column);
@@ -6472,6 +6849,7 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> url = const Value.absent(),
+            Value<String> itemType = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<String?> description = const Value.absent(),
             Value<String?> imageUrl = const Value.absent(),
@@ -6479,6 +6857,12 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             Value<bool> isFavorite = const Value.absent(),
             Value<String?> tags = const Value.absent(),
             Value<String?> memo = const Value.absent(),
+            Value<String?> productCode = const Value.absent(),
+            Value<String?> brand = const Value.absent(),
+            Value<String?> size = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+            Value<String?> category = const Value.absent(),
+            Value<String?> nutritionSource = const Value.absent(),
             Value<String?> ingredientsJson = const Value.absent(),
             Value<String?> ingredientsRawText = const Value.absent(),
             Value<double?> calories = const Value.absent(),
@@ -6497,6 +6881,7 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
               ExternalRecipeTableCompanion(
             id: id,
             url: url,
+            itemType: itemType,
             title: title,
             description: description,
             imageUrl: imageUrl,
@@ -6504,6 +6889,12 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             isFavorite: isFavorite,
             tags: tags,
             memo: memo,
+            productCode: productCode,
+            brand: brand,
+            size: size,
+            price: price,
+            category: category,
+            nutritionSource: nutritionSource,
             ingredientsJson: ingredientsJson,
             ingredientsRawText: ingredientsRawText,
             calories: calories,
@@ -6522,6 +6913,7 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String url,
+            Value<String> itemType = const Value.absent(),
             required String title,
             Value<String?> description = const Value.absent(),
             Value<String?> imageUrl = const Value.absent(),
@@ -6529,6 +6921,12 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             Value<bool> isFavorite = const Value.absent(),
             Value<String?> tags = const Value.absent(),
             Value<String?> memo = const Value.absent(),
+            Value<String?> productCode = const Value.absent(),
+            Value<String?> brand = const Value.absent(),
+            Value<String?> size = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+            Value<String?> category = const Value.absent(),
+            Value<String?> nutritionSource = const Value.absent(),
             Value<String?> ingredientsJson = const Value.absent(),
             Value<String?> ingredientsRawText = const Value.absent(),
             Value<double?> calories = const Value.absent(),
@@ -6547,6 +6945,7 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
               ExternalRecipeTableCompanion.insert(
             id: id,
             url: url,
+            itemType: itemType,
             title: title,
             description: description,
             imageUrl: imageUrl,
@@ -6554,6 +6953,12 @@ class $$ExternalRecipeTableTableTableManager extends RootTableManager<
             isFavorite: isFavorite,
             tags: tags,
             memo: memo,
+            productCode: productCode,
+            brand: brand,
+            size: size,
+            price: price,
+            category: category,
+            nutritionSource: nutritionSource,
             ingredientsJson: ingredientsJson,
             ingredientsRawText: ingredientsRawText,
             calories: calories,

--- a/lib/data/models/food_product_table.dart
+++ b/lib/data/models/food_product_table.dart
@@ -1,0 +1,115 @@
+import 'package:drift/drift.dart';
+
+/// 食品商品テーブル（市販商品の登録用）
+@DataClassName('FoodProductTableData')
+class FoodProductTable extends Table {
+  /// 商品ID（プライマリキー）
+  IntColumn get id => integer().autoIncrement()();
+  
+  /// 商品コード（JANコード等）
+  TextColumn get productCode => text().nullable()();
+  
+  /// 商品名
+  TextColumn get name => text()();
+  
+  /// ブランド名
+  TextColumn get brand => text().nullable()();
+  
+  /// 製造者・販売者
+  TextColumn get manufacturer => text().nullable()();
+  
+  /// 商品サイズ・容量
+  TextColumn get size => text().nullable()();
+  
+  /// 商品説明
+  TextColumn get description => text().nullable()();
+  
+  /// 商品画像URL
+  TextColumn get imageUrl => text().nullable()();
+  
+  /// 商品価格（円）
+  RealColumn get price => real().nullable()();
+  
+  /// 元サイトURL
+  TextColumn get sourceUrl => text().nullable()();
+  
+  /// 元サイト名
+  TextColumn get sourceSite => text().nullable()();
+  
+  /// カテゴリ
+  TextColumn get category => text().nullable()();
+  
+  // === 栄養成分（100gあたり） ===
+  
+  /// エネルギー（kcal）
+  RealColumn get calories => real().nullable()();
+  
+  /// タンパク質（g）
+  RealColumn get protein => real().nullable()();
+  
+  /// 脂質（g）
+  RealColumn get fat => real().nullable()();
+  
+  /// 炭水化物（g）
+  RealColumn get carbs => real().nullable()();
+  
+  /// 食塩相当量（g）
+  RealColumn get salt => real().nullable()();
+  
+  /// 食物繊維（g）
+  RealColumn get fiber => real().nullable()();
+  
+  /// ビタミンC（mg）
+  RealColumn get vitaminC => real().nullable()();
+  
+  /// ナトリウム（mg）
+  RealColumn get sodium => real().nullable()();
+  
+  /// カルシウム（mg）
+  RealColumn get calcium => real().nullable()();
+  
+  /// 鉄（mg）
+  RealColumn get iron => real().nullable()();
+  
+  /// カリウム（mg）
+  RealColumn get potassium => real().nullable()();
+  
+  // === 原材料・アレルギー情報 ===
+  
+  /// 原材料名（JSON形式）
+  TextColumn get ingredientsJson => text().nullable()();
+  
+  /// 原材料名（テキスト形式）
+  TextColumn get ingredientsText => text().nullable()();
+  
+  /// アレルギー情報（JSON形式）
+  TextColumn get allergensJson => text().nullable()();
+  
+  /// アレルギー情報（テキスト形式）
+  TextColumn get allergensText => text().nullable()();
+  
+  // === 商品分類・タグ ===
+  
+  /// 商品タグ（カンマ区切り）
+  TextColumn get tags => text().nullable()();
+  
+  /// お気に入りフラグ
+  BoolColumn get isFavorite => boolean().withDefault(const Constant(false))();
+  
+  /// ユーザーメモ
+  TextColumn get userMemo => text().nullable()();
+  
+  // === システム情報 ===
+  
+  /// 栄養情報の情報源（'直接抽出' | '手動入力' | '推測' など）
+  TextColumn get nutritionSource => text().nullable()();
+  
+  /// 最後にアクセスした日時
+  DateTimeColumn get lastAccessedAt => dateTime().nullable()();
+  
+  /// 作成日時
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  
+  /// 更新日時
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}

--- a/lib/data/models/meal_table.dart
+++ b/lib/data/models/meal_table.dart
@@ -80,6 +80,9 @@ class ExternalRecipeTable extends Table {
   /// レシピURL
   TextColumn get url => text().withLength(min: 1, max: 500).unique()();
   
+  /// アイテムタイプ（'recipe' | 'food_product'）
+  TextColumn get itemType => text().withLength(min: 1, max: 20).withDefault(const Constant('recipe'))();
+  
   /// タイトル（OGPから取得）
   TextColumn get title => text().withLength(min: 1, max: 200)();
   
@@ -100,6 +103,28 @@ class ExternalRecipeTable extends Table {
   
   /// メモ
   TextColumn get memo => text().nullable()();
+  
+  /// === 食品商品専用フィールド ===
+  
+  /// 商品コード（JANコード等）
+  TextColumn get productCode => text().nullable()();
+  
+  /// ブランド名
+  TextColumn get brand => text().nullable()();
+  
+  /// 商品サイズ・容量
+  TextColumn get size => text().nullable()();
+  
+  /// 商品価格（円）
+  RealColumn get price => real().nullable()();
+  
+  /// カテゴリ
+  TextColumn get category => text().nullable()();
+  
+  /// 栄養情報の情報源
+  TextColumn get nutritionSource => text().nullable()();
+  
+  /// === 共通フィールド ===
   
   /// 材料情報（JSON形式）
   TextColumn get ingredientsJson => text().nullable()();

--- a/lib/presentation/pages/meal_add_page.dart
+++ b/lib/presentation/pages/meal_add_page.dart
@@ -431,33 +431,55 @@ class MealAddPage extends HookConsumerWidget {
                     color: AppColors.primary.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
                   ),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
-                    child: recipe.imageUrl != null
-                        ? CachedNetworkImage(
-                            imageUrl: recipe.imageUrl!,
-                            width: 60.w,
-                            height: 60.w,
-                            fit: BoxFit.cover,
-                            placeholder: (context, url) => Container(
-                              color: AppColors.primary.withOpacity(0.1),
-                              child: Icon(
-                                Icons.restaurant,
+                  child: Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+                        child: recipe.imageUrl != null
+                            ? CachedNetworkImage(
+                                imageUrl: recipe.imageUrl!,
+                                width: 60.w,
+                                height: 60.w,
+                                fit: BoxFit.cover,
+                                placeholder: (context, url) => Container(
+                                  color: AppColors.primary.withOpacity(0.1),
+                                  child: Icon(
+                                    recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                                    color: AppColors.primary,
+                                    size: 24.w,
+                                  ),
+                                ),
+                                errorWidget: (context, url, error) => Icon(
+                                  recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                                  color: AppColors.primary,
+                                  size: 24.w,
+                                ),
+                              )
+                            : Icon(
+                                recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
                                 color: AppColors.primary,
                                 size: 24.w,
                               ),
+                      ),
+                      // アイテムタイプバッジ
+                      if (recipe.itemType == 'food_product')
+                        Positioned(
+                          top: 2.w,
+                          right: 2.w,
+                          child: Container(
+                            padding: EdgeInsets.all(2.w),
+                            decoration: BoxDecoration(
+                              color: AppColors.warning,
+                              borderRadius: BorderRadius.circular(4.r),
                             ),
-                            errorWidget: (context, url, error) => Icon(
-                              Icons.restaurant,
-                              color: AppColors.primary,
-                              size: 24.w,
+                            child: Icon(
+                              Icons.local_grocery_store,
+                              size: 12.w,
+                              color: Colors.white,
                             ),
-                          )
-                        : Icon(
-                            Icons.restaurant,
-                            color: AppColors.primary,
-                            size: 24.w,
                           ),
+                        ),
+                    ],
                   ),
                 ),
                 SizedBox(width: AppConstants.paddingM.w),
@@ -467,11 +489,34 @@ class MealAddPage extends HookConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        recipe.title,
-                        style: AppTextStyles.headline3,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      Row(
+                        children: [
+                          // タイプラベル
+                          Container(
+                            padding: EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
+                            decoration: BoxDecoration(
+                              color: recipe.itemType == 'food_product' ? AppColors.warning : AppColors.primary,
+                              borderRadius: BorderRadius.circular(4.r),
+                            ),
+                            child: Text(
+                              recipe.itemType == 'food_product' ? '食品' : 'レシピ',
+                              style: AppTextStyles.caption.copyWith(
+                                color: Colors.white,
+                                fontSize: 10.sp,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                          SizedBox(width: 6.w),
+                          Expanded(
+                            child: Text(
+                              recipe.title,
+                              style: AppTextStyles.headline3,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
                       ),
                       if (recipe.siteName != null) ...[
                         SizedBox(height: 4.h),

--- a/lib/presentation/pages/meal_management_page.dart
+++ b/lib/presentation/pages/meal_management_page.dart
@@ -873,7 +873,7 @@ class MealManagementPage extends HookConsumerWidget {
       child: Row(
         children: [
           // レシピ画像（ある場合のみ表示）
-          if (recipe?.imageUrl != null) ...[
+          if (recipe?.imageUrl != null || recipe != null) ...[
             Container(
               width: 50.w,
               height: 50.w,
@@ -881,27 +881,55 @@ class MealManagementPage extends HookConsumerWidget {
                 color: AppColors.primary.withOpacity(0.1),
                 borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
               ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
-                child: CachedNetworkImage(
-                  imageUrl: recipe!.imageUrl!,
-                  width: 50.w,
-                  height: 50.w,
-                  fit: BoxFit.cover,
-                  placeholder: (context, url) => Container(
-                    color: AppColors.primary.withOpacity(0.1),
-                    child: Icon(
-                      Icons.restaurant,
-                      color: AppColors.primary,
-                      size: 20.w,
+              child: Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
+                    child: recipe?.imageUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: recipe!.imageUrl!,
+                            width: 50.w,
+                            height: 50.w,
+                            fit: BoxFit.cover,
+                            placeholder: (context, url) => Container(
+                              color: AppColors.primary.withOpacity(0.1),
+                              child: Icon(
+                                recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                                color: AppColors.primary,
+                                size: 20.w,
+                              ),
+                            ),
+                            errorWidget: (context, url, error) => Icon(
+                              recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                              color: AppColors.primary,
+                              size: 20.w,
+                            ),
+                          )
+                        : Icon(
+                            recipe?.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                            color: AppColors.primary,
+                            size: 20.w,
+                          ),
+                  ),
+                  // アイテムタイプバッジ
+                  if (recipe?.itemType == 'food_product')
+                    Positioned(
+                      top: 1.w,
+                      right: 1.w,
+                      child: Container(
+                        padding: EdgeInsets.all(1.w),
+                        decoration: BoxDecoration(
+                          color: AppColors.warning,
+                          borderRadius: BorderRadius.circular(3.r),
+                        ),
+                        child: Icon(
+                          Icons.local_grocery_store,
+                          size: 8.w,
+                          color: Colors.white,
+                        ),
+                      ),
                     ),
-                  ),
-                  errorWidget: (context, url, error) => Icon(
-                    Icons.restaurant,
-                    color: AppColors.primary,
-                    size: 20.w,
-                  ),
-                ),
+                ],
               ),
             ),
             SizedBox(width: AppConstants.paddingM.w),
@@ -916,11 +944,36 @@ class MealManagementPage extends HookConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Expanded(
-                      child: Text(
-                        recipe?.title ?? mealWithRecipe.items.first.foodName,
-                        style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      child: Row(
+                        children: [
+                          // タイプラベル（レシピがある場合のみ）
+                          if (recipe != null) ...[
+                            Container(
+                              padding: EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.h),
+                              decoration: BoxDecoration(
+                                color: recipe.itemType == 'food_product' ? AppColors.warning : AppColors.primary,
+                                borderRadius: BorderRadius.circular(3.r),
+                              ),
+                              child: Text(
+                                recipe.itemType == 'food_product' ? '食品' : 'レシピ',
+                                style: AppTextStyles.caption.copyWith(
+                                  color: Colors.white,
+                                  fontSize: 8.sp,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 4.w),
+                          ],
+                          Expanded(
+                            child: Text(
+                              recipe?.title ?? mealWithRecipe.items.first.foodName,
+                              style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     Text(
@@ -1297,33 +1350,55 @@ class MealManagementPage extends HookConsumerWidget {
                     color: AppColors.primary.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
                   ),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
-                    child: imageUrl != null
-                        ? CachedNetworkImage(
-                            imageUrl: imageUrl,
-                            width: 60.w,
-                            height: 60.w,
-                            fit: BoxFit.cover,
-                            placeholder: (context, url) => Container(
-                              color: AppColors.primary.withOpacity(0.1),
-                              child: Icon(
-                                Icons.restaurant,
+                  child: Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+                        child: imageUrl != null
+                            ? CachedNetworkImage(
+                                imageUrl: imageUrl,
+                                width: 60.w,
+                                height: 60.w,
+                                fit: BoxFit.cover,
+                                placeholder: (context, url) => Container(
+                                  color: AppColors.primary.withOpacity(0.1),
+                                  child: Icon(
+                                    recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                                    color: AppColors.primary,
+                                    size: 24.w,
+                                  ),
+                                ),
+                                errorWidget: (context, url, error) => Icon(
+                                  recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
+                                  color: AppColors.primary,
+                                  size: 24.w,
+                                ),
+                              )
+                            : Icon(
+                                recipe.itemType == 'food_product' ? Icons.shopping_cart : Icons.restaurant,
                                 color: AppColors.primary,
                                 size: 24.w,
                               ),
+                      ),
+                      // アイテムタイプバッジ
+                      if (recipe.itemType == 'food_product')
+                        Positioned(
+                          top: 2.w,
+                          right: 2.w,
+                          child: Container(
+                            padding: EdgeInsets.all(2.w),
+                            decoration: BoxDecoration(
+                              color: AppColors.warning,
+                              borderRadius: BorderRadius.circular(4.r),
                             ),
-                            errorWidget: (context, url, error) => Icon(
-                              Icons.restaurant,
-                              color: AppColors.primary,
-                              size: 24.w,
+                            child: Icon(
+                              Icons.local_grocery_store,
+                              size: 12.w,
+                              color: Colors.white,
                             ),
-                          )
-                        : Icon(
-                            Icons.restaurant,
-                            color: AppColors.primary,
-                            size: 24.w,
                           ),
+                        ),
+                    ],
                   ),
                 ),
                 SizedBox(width: AppConstants.paddingM.w),
@@ -1333,11 +1408,34 @@ class MealManagementPage extends HookConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        title,
-                        style: AppTextStyles.headline3,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      Row(
+                        children: [
+                          // タイプラベル
+                          Container(
+                            padding: EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
+                            decoration: BoxDecoration(
+                              color: recipe.itemType == 'food_product' ? AppColors.warning : AppColors.primary,
+                              borderRadius: BorderRadius.circular(4.r),
+                            ),
+                            child: Text(
+                              recipe.itemType == 'food_product' ? '食品' : 'レシピ',
+                              style: AppTextStyles.caption.copyWith(
+                                color: Colors.white,
+                                fontSize: 10.sp,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                          SizedBox(width: 6.w),
+                          Expanded(
+                            child: Text(
+                              title,
+                              style: AppTextStyles.headline3,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
                       ),
                       SizedBox(height: 4.h),
                       Text(
@@ -1445,11 +1543,34 @@ class MealManagementPage extends HookConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  recipe.title,
-                  style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                Row(
+                  children: [
+                    // タイプラベル
+                    Container(
+                      padding: EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.h),
+                      decoration: BoxDecoration(
+                        color: recipe.itemType == 'food_product' ? AppColors.warning : AppColors.primary,
+                        borderRadius: BorderRadius.circular(3.r),
+                      ),
+                      child: Text(
+                        recipe.itemType == 'food_product' ? '食品' : 'レシピ',
+                        style: AppTextStyles.caption.copyWith(
+                          color: Colors.white,
+                          fontSize: 8.sp,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    SizedBox(width: 4.w),
+                    Expanded(
+                      child: Text(
+                        recipe.title,
+                        style: AppTextStyles.body2.copyWith(fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
                 ),
                 if (recipe.siteName != null) ...[
                   SizedBox(height: 2.h),

--- a/lib/presentation/pages/recipe_url_register_page.dart
+++ b/lib/presentation/pages/recipe_url_register_page.dart
@@ -372,10 +372,24 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
                   color: AppColors.success,
                 ),
                 SizedBox(width: 8.w),
-                Text(
-                  '栄養情報を自動分析しました',
-                  style: AppTextStyles.headline3.copyWith(
-                    color: AppColors.success,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '栄養情報を自動分析しました',
+                        style: AppTextStyles.headline3.copyWith(
+                          color: AppColors.success,
+                        ),
+                      ),
+                      if (_ogpData?.nutrition != null && _ogpData!.nutrition!.isValid)
+                        Text(
+                          '情報源: ${_ogpData!.nutrition!.source}',
+                          style: AppTextStyles.caption.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
               ],
@@ -501,10 +515,11 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
       final ogpData = await _ogpFetcher.fetchOgpData(_urlController.text);
       
       // OGP取得後、レシピ本文があれば栄養分析を実行
+      // 直接抽出された栄養情報を優先して使用
       RecipeNutritionResult? nutritionResult;
       if (ogpData.recipeText != null && ogpData.recipeText!.isNotEmpty) {
         try {
-          nutritionResult = await _nutritionService.analyzeRecipe(ogpData.recipeText!);
+          nutritionResult = await _nutritionService.analyzeRecipe(ogpData.recipeText!, ogpData.nutrition);
         } catch (e) {
           print('栄養分析エラー: $e');
         }

--- a/lib/presentation/pages/recipe_url_register_page.dart
+++ b/lib/presentation/pages/recipe_url_register_page.dart
@@ -2,16 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:http/http.dart' as http;
+import 'package:html/parser.dart' as html_parser;
 
 import '../../core/themes/app_colors.dart';
 import '../../core/themes/app_text_styles.dart';
 import '../../core/constants/app_constants.dart';
 import '../../core/services/ogp_fetcher_service.dart';
 import '../../core/services/recipe_nutrition_analysis_service.dart';
+import '../../core/services/food_product_extraction_service.dart';
 import '../providers/database_provider.dart';
 import 'recipe_viewer_page.dart';
 
-/// レシピURL登録ページ
+/// 登録タイプの列挙型
+enum RegisterType { recipe, foodProduct }
+
+/// レシピ・食品URL登録ページ
 class RecipeUrlRegisterPage extends ConsumerStatefulWidget {
   const RecipeUrlRegisterPage({super.key});
 
@@ -26,11 +32,14 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
   final _formKey = GlobalKey<FormState>();
   
   final _ogpFetcher = OgpFetcherService();
+  final _foodProductExtractor = FoodProductExtractionService();
   late final RecipeNutritionAnalysisService _nutritionService;
   
   bool _isLoading = false;
+  RegisterType _selectedType = RegisterType.recipe;
   OgpData? _ogpData;
   RecipeNutritionResult? _nutritionResult;
+  FoodProductInfo? _foodProductInfo;
   String? _errorMessage;
 
   @override
@@ -49,7 +58,7 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
       backgroundColor: AppColors.background,
       appBar: AppBar(
         title: Text(
-          'レシピURL登録',
+          '${_selectedType == RegisterType.recipe ? 'レシピ' : '食品'}登録',
           style: AppTextStyles.headline2,
         ),
       ),
@@ -61,6 +70,10 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                // タイプ選択
+                _buildTypeSelector(),
+                SizedBox(height: AppConstants.paddingM.h),
+                
                 // URL入力フィールド
                 _buildUrlField(),
                 SizedBox(height: AppConstants.paddingM.h),
@@ -74,6 +87,12 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
                 // 栄養情報プレビュー
                 if (_nutritionResult != null) ...[
                   _buildNutritionPreview(),
+                  SizedBox(height: AppConstants.paddingL.h),
+                ],
+                
+                // 食品情報プレビュー
+                if (_foodProductInfo != null) ...[
+                  _buildFoodProductPreview(),
                   SizedBox(height: AppConstants.paddingL.h),
                 ],
                 
@@ -327,7 +346,7 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
     return SizedBox(
       width: double.infinity,
       child: ElevatedButton.icon(
-        onPressed: (_ogpData != null && !saveState.isLoading) ? _saveRecipe : null,
+        onPressed: ((_ogpData != null || _foodProductInfo != null) && !saveState.isLoading) ? _saveRecipe : null,
         icon: saveState.isLoading 
           ? SizedBox(
               width: 20.w,
@@ -509,25 +528,39 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
       _isLoading = true;
       _errorMessage = null;
       _ogpData = null;
+      _nutritionResult = null;
+      _foodProductInfo = null;
     });
     
     try {
       final ogpData = await _ogpFetcher.fetchOgpData(_urlController.text);
       
-      // OGP取得後、レシピ本文があれば栄養分析を実行
-      // 直接抽出された栄養情報を優先して使用
       RecipeNutritionResult? nutritionResult;
-      if (ogpData.recipeText != null && ogpData.recipeText!.isNotEmpty) {
+      FoodProductInfo? foodProductInfo;
+      
+      if (_selectedType == RegisterType.recipe) {
+        // レシピの場合：栄養分析を実行
+        if (ogpData.recipeText != null && ogpData.recipeText!.isNotEmpty) {
+          try {
+            nutritionResult = await _nutritionService.analyzeRecipe(ogpData.recipeText!, ogpData.nutrition);
+          } catch (e) {
+            print('栄養分析エラー: $e');
+          }
+        }
+      } else {
+        // 食品の場合：商品情報を抽出
         try {
-          nutritionResult = await _nutritionService.analyzeRecipe(ogpData.recipeText!, ogpData.nutrition);
+          final htmlParser = html_parser.parse(await http.get(Uri.parse(_urlController.text)).then((response) => response.body));
+          foodProductInfo = _foodProductExtractor.extractFoodProductFromHtml(htmlParser, _urlController.text);
         } catch (e) {
-          print('栄養分析エラー: $e');
+          print('食品情報抽出エラー: $e');
         }
       }
       
       setState(() {
         _ogpData = ogpData;
         _nutritionResult = nutritionResult;
+        _foodProductInfo = foodProductInfo;
         _isLoading = false;
       });
     } catch (e) {
@@ -539,23 +572,47 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
   }
 
   Future<void> _saveRecipe() async {
-    if (_ogpData == null) return;
+    if (_ogpData == null && _foodProductInfo == null) return;
     
     // データベースに保存
     final recipeNotifier = ref.read(recipeRegistrationProvider.notifier);
     
-    // 栄養分析結果を含めて保存
-    await recipeNotifier.saveExternalRecipeWithNutrition(
-      url: _urlController.text,
-      title: _ogpData!.title ?? 'タイトルなし',
-      description: _ogpData!.description,
-      imageUrl: _ogpData!.imageUrl,
-      siteName: _ogpData!.siteName,
-      tags: _tagsController.text.isNotEmpty ? _tagsController.text : null,
-      memo: _memoController.text.isNotEmpty ? _memoController.text : null,
-      recipeText: _ogpData!.recipeText,
-      nutritionResult: _nutritionResult, // 栄養分析結果
-    );
+    if (_selectedType == RegisterType.recipe && _ogpData != null) {
+      // レシピとして保存
+      await recipeNotifier.saveExternalRecipeWithNutrition(
+        url: _urlController.text,
+        title: _ogpData!.title ?? 'タイトルなし',
+        description: _ogpData!.description,
+        imageUrl: _ogpData!.imageUrl,
+        siteName: _ogpData!.siteName,
+        tags: _tagsController.text.isNotEmpty ? _tagsController.text : null,
+        memo: _memoController.text.isNotEmpty ? _memoController.text : null,
+        recipeText: _ogpData!.recipeText,
+        nutritionResult: _nutritionResult,
+        itemType: 'recipe',
+      );
+    } else if (_selectedType == RegisterType.foodProduct && _foodProductInfo != null) {
+      // 食品として保存
+      await recipeNotifier.saveExternalRecipeWithNutrition(
+        url: _urlController.text,
+        title: _foodProductInfo!.name,
+        description: _foodProductInfo!.description,
+        imageUrl: _foodProductInfo!.imageUrl,
+        siteName: _foodProductInfo!.sourceSite,
+        tags: _tagsController.text.isNotEmpty ? _tagsController.text : null,
+        memo: _memoController.text.isNotEmpty ? _memoController.text : null,
+        recipeText: null,
+        nutritionResult: _foodProductInfo!.nutrition != null ? _createNutritionResultFromFoodProduct(_foodProductInfo!) : null,
+        itemType: 'food_product',
+        // 食品専用フィールド
+        productCode: _foodProductInfo!.productCode,
+        brand: _foodProductInfo!.brand,
+        size: _foodProductInfo!.size,
+        price: _foodProductInfo!.price,
+        category: _foodProductInfo!.category,
+        nutritionSource: _foodProductInfo!.nutritionSource,
+      );
+    }
     
     // 保存状態を監視
     final saveState = ref.read(recipeRegistrationProvider);
@@ -585,6 +642,246 @@ class _RecipeUrlRegisterPageState extends ConsumerState<RecipeUrlRegisterPage> {
           ),
         );
       },
+    );
+  }
+
+  /// タイプ選択UI
+  Widget _buildTypeSelector() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '登録タイプを選択',
+          style: AppTextStyles.headline3,
+        ),
+        SizedBox(height: AppConstants.paddingS.h),
+        Container(
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _selectedType = RegisterType.recipe;
+                      _clearData();
+                    });
+                  },
+                  child: Container(
+                    padding: EdgeInsets.symmetric(vertical: 12.h),
+                    decoration: BoxDecoration(
+                      color: _selectedType == RegisterType.recipe 
+                          ? AppColors.primary 
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+                    ),
+                    child: Text(
+                      'レシピ',
+                      textAlign: TextAlign.center,
+                      style: AppTextStyles.body1.copyWith(
+                        color: _selectedType == RegisterType.recipe 
+                            ? Colors.white 
+                            : AppColors.textSecondary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _selectedType = RegisterType.foodProduct;
+                      _clearData();
+                    });
+                  },
+                  child: Container(
+                    padding: EdgeInsets.symmetric(vertical: 12.h),
+                    decoration: BoxDecoration(
+                      color: _selectedType == RegisterType.foodProduct 
+                          ? AppColors.primary 
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+                    ),
+                    child: Text(
+                      '食品・商品',
+                      textAlign: TextAlign.center,
+                      style: AppTextStyles.body1.copyWith(
+                        color: _selectedType == RegisterType.foodProduct 
+                            ? Colors.white 
+                            : AppColors.textSecondary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// データをクリア
+  void _clearData() {
+    setState(() {
+      _ogpData = null;
+      _nutritionResult = null;
+      _foodProductInfo = null;
+      _errorMessage = null;
+    });
+  }
+
+  /// 食品情報から栄養分析結果を作成
+  RecipeNutritionResult _createNutritionResultFromFoodProduct(FoodProductInfo foodInfo) {
+    return RecipeNutritionResult(
+      ingredients: [],
+      matchResults: [],
+      nutrition: RecipeNutrition(
+        energy: foodInfo.nutrition!.calories,
+        protein: foodInfo.nutrition!.protein,
+        fat: foodInfo.nutrition!.fat,
+        carbohydrate: foodInfo.nutrition!.carbs,
+        salt: foodInfo.nutrition!.salt,
+        fiber: foodInfo.nutrition!.fiber,
+        vitaminC: foodInfo.nutrition!.vitaminC,
+      ),
+      pfcBalance: PFCBalance(protein: 0, fat: 0, carbohydrate: 0), // 計算は省略
+      extractionStats: {},
+      ingredientsJson: '[]',
+      rawText: '',
+    );
+  }
+
+  /// 食品情報プレビュー
+  Widget _buildFoodProductPreview() {
+    if (_foodProductInfo == null) return const SizedBox.shrink();
+    
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+        border: Border.all(
+          color: AppColors.success.withOpacity(0.3),
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(AppConstants.paddingM.w),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.shopping_cart,
+                  size: 20.w,
+                  color: AppColors.success,
+                ),
+                SizedBox(width: 8.w),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '食品情報を取得しました',
+                        style: AppTextStyles.headline3.copyWith(
+                          color: AppColors.success,
+                        ),
+                      ),
+                      if (_foodProductInfo!.nutritionSource != null)
+                        Text(
+                          '情報源: ${_foodProductInfo!.nutritionSource}',
+                          style: AppTextStyles.caption.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: AppConstants.paddingM.h),
+            
+            // 商品情報
+            if (_foodProductInfo!.brand != null) ...[
+              Text(
+                'ブランド: ${_foodProductInfo!.brand}',
+                style: AppTextStyles.body2,
+              ),
+              SizedBox(height: 4.h),
+            ],
+            if (_foodProductInfo!.size != null) ...[
+              Text(
+                'サイズ: ${_foodProductInfo!.size}',
+                style: AppTextStyles.body2,
+              ),
+              SizedBox(height: 4.h),
+            ],
+            if (_foodProductInfo!.price != null) ...[
+              Text(
+                '価格: ¥${_foodProductInfo!.price!.toStringAsFixed(0)}',
+                style: AppTextStyles.body2.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              SizedBox(height: AppConstants.paddingM.h),
+            ],
+            
+            // 栄養情報
+            if (_foodProductInfo!.nutrition != null) ...[
+              Container(
+                padding: EdgeInsets.all(AppConstants.paddingS.w),
+                decoration: BoxDecoration(
+                  color: AppColors.background,
+                  borderRadius: BorderRadius.circular(AppConstants.radiusS.r),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _buildNutritionItem(
+                        'エネルギー',
+                        '${_foodProductInfo!.nutrition!.calories.toStringAsFixed(0)} kcal',
+                        Icons.local_fire_department,
+                        AppColors.error,
+                      ),
+                    ),
+                    Expanded(
+                      child: _buildNutritionItem(
+                        'タンパク質',
+                        '${_foodProductInfo!.nutrition!.protein.toStringAsFixed(1)} g',
+                        Icons.fitness_center,
+                        AppColors.primary,
+                      ),
+                    ),
+                    Expanded(
+                      child: _buildNutritionItem(
+                        '脂質',
+                        '${_foodProductInfo!.nutrition!.fat.toStringAsFixed(1)} g',
+                        Icons.water_drop,
+                        AppColors.warning,
+                      ),
+                    ),
+                    Expanded(
+                      child: _buildNutritionItem(
+                        '炭水化物',
+                        '${_foodProductInfo!.nutrition!.carbs.toStringAsFixed(1)} g',
+                        Icons.grain,
+                        AppColors.success,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/presentation/providers/database_provider.dart
+++ b/lib/presentation/providers/database_provider.dart
@@ -184,7 +184,7 @@ class RecipeRegistrationNotifier extends StateNotifier<AsyncValue<void>> {
     }
   }
 
-  /// 外部レシピを栄養分析結果と一緒に保存
+  /// 外部レシピ・食品を栄養分析結果と一緒に保存
   Future<void> saveExternalRecipeWithNutrition({
     required String url,
     required String title,
@@ -195,6 +195,14 @@ class RecipeRegistrationNotifier extends StateNotifier<AsyncValue<void>> {
     String? memo,
     String? recipeText,
     RecipeNutritionResult? nutritionResult,
+    String itemType = 'recipe',
+    // 食品専用フィールド
+    String? productCode,
+    String? brand,
+    String? size,
+    double? price,
+    String? category,
+    String? nutritionSource,
   }) async {
     state = const AsyncValue.loading();
     
@@ -205,10 +213,11 @@ class RecipeRegistrationNotifier extends StateNotifier<AsyncValue<void>> {
         throw Exception('このレシピは既に登録されています');
       }
       
-      // 新しいレシピを保存
+      // 新しいレシピ・食品を保存
       await _database.insertExternalRecipe(
         ExternalRecipeTableCompanion.insert(
           url: url,
+          itemType: Value(itemType),
           title: title,
           description: description != null ? Value(description) : const Value.absent(),
           imageUrl: imageUrl != null ? Value(imageUrl) : const Value.absent(),

--- a/lib/presentation/providers/database_provider.dart
+++ b/lib/presentation/providers/database_provider.dart
@@ -54,13 +54,13 @@ final todayPersonalDataProvider = FutureProvider<PersonalDataTableData?>((ref) a
   }
 });
 
-// お気に入りレシピプロバイダー
+// お気に入りレシピ・食品プロバイダー（レシピと食品の両方を含む）
 final favoriteRecipesProvider = FutureProvider<List<ExternalRecipeTableData>>((ref) async {
   final database = ref.watch(databaseProvider);
   return await database.getFavoriteRecipes();
 });
 
-// 最近のレシピプロバイダー
+// 最近のレシピ・食品プロバイダー（レシピと食品の両方を含む）
 final recentRecipesProvider = FutureProvider<List<ExternalRecipeTableData>>((ref) async {
   final database = ref.watch(databaseProvider);
   return await database.getRecentRecipes(limit: 10);


### PR DESCRIPTION
## Summary
レシピと食品商品を統合管理するシステムを実装しました。ユーザーは単一のインターフェースでレシピと食品を登録・管理でき、食事記録時にも区別なく選択できるようになります。

### 主要な機能
- **統合登録** - レシピとECサイト商品の両方をURLから自動登録
- **栄養情報自動抽出** - HTML直接抽出を優先し、材料推測をフォールバックとして使用
- **視覚的区別** - レシピ・食品をラベル、アイコン、バッジで識別
- **統一管理** - 同一データベーステーブルで効率的に管理

### 技術実装
- `itemType`フィールドによるレシピ・食品区別機能
- `FoodProductExtractionService`による商品情報自動抽出
- `NutritionExtractionService`による栄養情報の優先度システム
- データベーススキーマv3への移行と新フィールド追加

### UI改善
- レシピ登録画面でタイプ選択機能を追加
- レシピ一覧・食事記録でタイプ別表示を実装
- 食事選択時にレシピ・食品両方から選択可能

## Test plan
- [x] レシピURLからの自動登録とデータ保存
- [x] 食品URLからの商品情報・栄養情報抽出
- [x] レシピ一覧でのタイプ別視覚化
- [x] 食事記録でのレシピ・食品選択
- [x] データベースマイグレーション動作確認
- [x] 型チェック完了（Flutter analyze）