### PR TITLE
fix: 体重チャートの移動平均表示を修正

### DIFF
--- a/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PreviewsEnabled</key>
-	<false/>
-</dict>
-</plist>

--- a/lib/core/utils/chart_utils.dart
+++ b/lib/core/utils/chart_utils.dart
@@ -3,11 +3,12 @@ import '../services/health_service.dart';
 
 /// チャート関連のユーティリティクラス
 class ChartUtils {
-  /// 7日移動平均を計算
+  /// 移動平均を計算（表示期間のみ返すオプション付き）
   static List<FlSpot> calculateMovingAverage(
     List<WeightData> data, 
-    int period,
-  ) {
+    int period, {
+    int? displayDays, // 表示期間を指定（nullの場合は全期間）
+  }) {
     if (data.length < period) return [];
     
     List<FlSpot> movingAverageSpots = [];
@@ -19,14 +20,34 @@ class ChartUtils {
       }
       double average = sum / period;
       
-      movingAverageSpots.add(FlSpot(i.toDouble(), average));
+      // 表示期間が指定されている場合は、表示期間のインデックスに調整
+      if (displayDays != null) {
+        final displayStartIndex = data.length - displayDays;
+        if (i >= displayStartIndex) {
+          final displayIndex = i - displayStartIndex;
+          movingAverageSpots.add(FlSpot(displayIndex.toDouble(), average));
+        }
+      } else {
+        movingAverageSpots.add(FlSpot(i.toDouble(), average));
+      }
     }
     
     return movingAverageSpots;
   }
   
-  /// WeightDataをFlSpotに変換
-  static List<FlSpot> convertToFlSpots(List<WeightData> data) {
+  /// WeightDataをFlSpotに変換（表示期間のみ返すオプション付き）
+  static List<FlSpot> convertToFlSpots(
+    List<WeightData> data, {
+    int? displayDays, // 表示期間を指定（nullの場合は全期間）
+  }) {
+    if (displayDays != null && data.length > displayDays) {
+      // 表示期間のデータのみを取得（最新のdisplayDays分）
+      final displayData = data.skip(data.length - displayDays).toList();
+      return displayData.asMap().entries.map((entry) {
+        return FlSpot(entry.key.toDouble(), entry.value.weight);
+      }).toList();
+    }
+    
     return data.asMap().entries.map((entry) {
       return FlSpot(entry.key.toDouble(), entry.value.weight);
     }).toList();

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -549,23 +549,26 @@ class HealthDataPage extends HookConsumerWidget {
   Widget _buildWeightChartSection(WidgetRef ref) {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
-    return weightHistoryAsync.when(
-      data: (weightData) => WeightChartWidgetHealth(
-        weightData: weightData,
-        onRefresh: () {
-          ref.invalidate(weightHistoryProvider);
-        },
-      ),
-      loading: () => WeightChartWidgetHealth(
-        weightData: const [],
-        isLoading: true,
-      ),
-      error: (error, stack) => WeightChartWidgetHealth(
-        weightData: const [],
-        errorMessage: error.toString(),
-        onRefresh: () {
-          ref.invalidate(weightHistoryProvider);
-        },
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: -AppConstants.paddingM.w), // 親のパディングを打ち消し
+      child: weightHistoryAsync.when(
+        data: (weightData) => WeightChartWidgetHealth(
+          weightData: weightData,
+          onRefresh: () {
+            ref.invalidate(weightHistoryProvider);
+          },
+        ),
+        loading: () => WeightChartWidgetHealth(
+          weightData: const [],
+          isLoading: true,
+        ),
+        error: (error, stack) => WeightChartWidgetHealth(
+          weightData: const [],
+          errorMessage: error.toString(),
+          onRefresh: () {
+            ref.invalidate(weightHistoryProvider);
+          },
+        ),
       ),
     );
   }

--- a/lib/presentation/providers/database_provider.dart
+++ b/lib/presentation/providers/database_provider.dart
@@ -66,14 +66,18 @@ final recentRecipesProvider = FutureProvider<List<ExternalRecipeTableData>>((ref
   return await database.getRecentRecipes(limit: 10);
 });
 
-// 体重履歴プロバイダー（一時的なダミーデータ）
+// 体重履歴プロバイダー（移動平均対応版）
 final weightHistoryProvider = FutureProvider<List<WeightData>>((ref) async {
   // 一時的なダミーデータを返す
   await Future.delayed(const Duration(milliseconds: 500));
   
   final now = DateTime.now();
-  return List.generate(30, (index) {
-    final date = now.subtract(Duration(days: 29 - index));
+  const displayDays = 30; // 表示期間
+  const movingAveragePeriod = 7; // 移動平均期間
+  const totalDays = displayDays + movingAveragePeriod - 1; // 移動平均計算に必要な総日数
+  
+  return List.generate(totalDays, (index) {
+    final date = now.subtract(Duration(days: totalDays - 1 - index));
     final baseWeight = 70.0;
     final variation = (index % 7 - 3) * 0.3; // 週次変動
     final trend = -index * 0.05; // 減少トレンド

--- a/lib/presentation/widgets/weight_chart_widget_health.dart
+++ b/lib/presentation/widgets/weight_chart_widget_health.dart
@@ -107,14 +107,14 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
 
   Widget _buildChart(BuildContext context, bool isDark) {
     return SizedBox(
-      height: 240.h,
-      child: widget.isLoading
-        ? _buildLoadingState(isDark)
-        : widget.errorMessage != null
-          ? _buildErrorState(widget.errorMessage!, isDark)
-          : widget.weightData.isEmpty
-            ? _buildEmptyState(isDark)
-            : _buildChartContent(isDark),
+      height: 180.h,
+        child: widget.isLoading
+          ? _buildLoadingState(isDark)
+          : widget.errorMessage != null
+            ? _buildErrorState(widget.errorMessage!, isDark)
+            : widget.weightData.isEmpty
+              ? _buildEmptyState(isDark)
+              : _buildChartContent(isDark),
     );
   }
 
@@ -122,12 +122,9 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
     return AnimatedBuilder(
       animation: _chartAnimation,
       builder: (context, child) {
-        return Padding(
-          padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 8.h, bottom: 0.h),
-          child: LineChart(
-            _buildLineChartData(isDark),
-            duration: const Duration(milliseconds: 0),
-          ),
+        return LineChart(
+          _buildLineChartData(isDark),
+          duration: const Duration(milliseconds: 0),
         );
       },
     );
@@ -158,7 +155,7 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
         leftTitles: AxisTitles(
           sideTitles: SideTitles(
             showTitles: true,
-            reservedSize: 40.w,
+            reservedSize: 35.w,
             getTitlesWidget: (value, meta) => _buildYAxisLabel(value, meta, isDark),
             interval: 2,
           ),
@@ -296,7 +293,7 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
 
   Widget _buildYAxisLabel(double value, TitleMeta meta, bool isDark) {
     return Padding(
-      padding: EdgeInsets.only(right: 8.w),
+      padding: EdgeInsets.only(right: 4.w),
       child: Text(
         value.toStringAsFixed(0),
         style: TextStyle(
@@ -323,7 +320,7 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
 
     final date = widget.weightData[actualIndex].date;
     return Padding(
-      padding: EdgeInsets.only(top: 8.h),
+      padding: EdgeInsets.only(top: 6.h),
       child: Text(
         '${date.month}/${date.day}',
         style: TextStyle(

--- a/lib/presentation/widgets/weight_chart_widget_health.dart
+++ b/lib/presentation/widgets/weight_chart_widget_health.dart
@@ -76,12 +76,14 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
 
   void _updateCachedData() {
     if (widget.weightData.isNotEmpty) {
-      final processedData = ChartUtils.downsampleData(widget.weightData, 30);
+      const displayDays = 30; // 表示期間
+      
+      // 表示期間のデータのみを取得（移動平均計算のため全データを保持）
       _cachedWeightSpots = ChartUtils.validateChartData(
-        ChartUtils.convertToFlSpots(processedData)
+        ChartUtils.convertToFlSpots(widget.weightData, displayDays: displayDays)
       );
       _cachedMovingAverageSpots = ChartUtils.validateChartData(
-        ChartUtils.calculateMovingAverage(processedData, 7)
+        ChartUtils.calculateMovingAverage(widget.weightData, 7, displayDays: displayDays)
       );
       _cachedBounds = ChartUtils.calculateSafeBounds(
         [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
@@ -309,11 +311,17 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
 
   Widget _buildXAxisLabel(double value, TitleMeta meta, bool isDark) {
     final index = value.toInt();
-    if (index < 0 || index >= widget.weightData.length) {
+    const displayDays = 30;
+    
+    // 表示期間のデータのみを使用
+    final displayStartIndex = widget.weightData.length - displayDays;
+    final actualIndex = displayStartIndex + index;
+    
+    if (actualIndex < 0 || actualIndex >= widget.weightData.length) {
       return const SizedBox.shrink();
     }
 
-    final date = widget.weightData[index].date;
+    final date = widget.weightData[actualIndex].date;
     return Padding(
       padding: EdgeInsets.only(top: 8.h),
       child: Text(
@@ -330,9 +338,14 @@ class _WeightChartWidgetHealthState extends State<WeightChartWidgetHealth>
   List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots, bool isDark) {
     return touchedSpots.map((barSpot) {
       final index = barSpot.x.toInt();
+      const displayDays = 30;
       
-      if (index >= 0 && index < widget.weightData.length) {
-        final data = widget.weightData[index];
+      // 表示期間のデータのみを使用
+      final displayStartIndex = widget.weightData.length - displayDays;
+      final actualIndex = displayStartIndex + index;
+      
+      if (actualIndex >= 0 && actualIndex < widget.weightData.length) {
+        final data = widget.weightData[actualIndex];
         final isAverage = barSpot.barIndex == 1;
         
         return LineTooltipItem(

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -114,11 +114,11 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
       ),
       child: Padding(
         padding: EdgeInsets.only(left: 0.w, right: 16.w, top: 20.h, bottom: 5.h),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildChart(context, colorScheme, isDark),
-          ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildChart(context, colorScheme, isDark),
+            ],
         ),
       ),
     );
@@ -127,13 +127,13 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
   Widget _buildChart(BuildContext context, ColorScheme colorScheme, bool isDark) {
     return SizedBox(
       height: 180.h,
-      child: widget.isLoading
-        ? _buildLoadingState(isDark)
-        : widget.errorMessage != null
-          ? _buildErrorState(widget.errorMessage!, isDark)
-          : widget.weightData.isEmpty
-            ? _buildEmptyState(isDark)
-            : _buildChartContent(colorScheme, isDark),
+        child: widget.isLoading
+          ? _buildLoadingState(isDark)
+          : widget.errorMessage != null
+            ? _buildErrorState(widget.errorMessage!, isDark)
+            : widget.weightData.isEmpty
+              ? _buildEmptyState(isDark)
+              : _buildChartContent(colorScheme, isDark),
     );
   }
 

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -76,12 +76,14 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
 
   void _updateCachedData() {
     if (widget.weightData.isNotEmpty) {
-      final processedData = ChartUtils.downsampleData(widget.weightData, 30);
+      const displayDays = 30; // 表示期間
+      
+      // 表示期間のデータのみを取得（移動平均計算のため全データを保持）
       _cachedWeightSpots = ChartUtils.validateChartData(
-        ChartUtils.convertToFlSpots(processedData)
+        ChartUtils.convertToFlSpots(widget.weightData, displayDays: displayDays)
       );
       _cachedMovingAverageSpots = ChartUtils.validateChartData(
-        ChartUtils.calculateMovingAverage(processedData, 7)
+        ChartUtils.calculateMovingAverage(widget.weightData, 7, displayDays: displayDays)
       );
       _cachedBounds = ChartUtils.calculateSafeBounds(
         [..._cachedWeightSpots, ..._cachedMovingAverageSpots],
@@ -326,11 +328,17 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
 
   Widget _buildXAxisLabel(double value, TitleMeta meta, bool isDark) {
     final index = value.toInt();
-    if (index < 0 || index >= widget.weightData.length) {
+    const displayDays = 30;
+    
+    // 表示期間のデータのみを使用
+    final displayStartIndex = widget.weightData.length - displayDays;
+    final actualIndex = displayStartIndex + index;
+    
+    if (actualIndex < 0 || actualIndex >= widget.weightData.length) {
       return const SizedBox.shrink();
     }
 
-    final date = widget.weightData[index].date;
+    final date = widget.weightData[actualIndex].date;
     return Padding(
       padding: EdgeInsets.only(top: 6.h),
       child: Text(
@@ -347,9 +355,14 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
   List<LineTooltipItem> _buildTooltipItems(List<LineBarSpot> touchedSpots, bool isDark) {
     return touchedSpots.map((barSpot) {
       final index = barSpot.x.toInt();
+      const displayDays = 30;
       
-      if (index >= 0 && index < widget.weightData.length) {
-        final data = widget.weightData[index];
+      // 表示期間のデータのみを使用
+      final displayStartIndex = widget.weightData.length - displayDays;
+      final actualIndex = displayStartIndex + index;
+      
+      if (actualIndex >= 0 && actualIndex < widget.weightData.length) {
+        final data = widget.weightData[actualIndex];
         final isAverage = barSpot.barIndex == 1;
         
         return LineTooltipItem(


### PR DESCRIPTION
## 概要
体重チャートの移動平均表示に関する不具合を修正しました。

## 変更内容
- 移動平均計算ロジックの実装（7日間移動平均）
- 表示期間の最適化（直近30日間のデータ表示）
- ホーム画面と身体活動画面でのグラフサイズと表示の統一

## 動作確認
- ホーム画面の体重グラフで移動平均線が正しく表示される
- 身体活動画面の体重グラフで移動平均線が正しく表示される
- 両画面でグラフサイズが統一されている