### PR TITLE
feat: UIの簡素化とデザイン統一

### DIFF
--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -62,9 +62,6 @@ class HealthDataPage extends HookConsumerWidget {
                 ),
                 SizedBox(height: AppConstants.paddingM.h),
 
-                // 手動入力ボタン
-                _buildManualInputButton(context),
-                SizedBox(height: AppConstants.paddingL.h),
               ],
             ),
           ),
@@ -346,11 +343,6 @@ class HealthDataPage extends HookConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '体重・体脂肪率',
-            style: AppTextStyles.headline3,
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
           
           Row(
             children: [
@@ -405,46 +397,54 @@ class HealthDataPage extends HookConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '直近24時間の活動',
-            style: AppTextStyles.headline3,
+          // アクティビティメトリクス（2列2行）
+          Row(
+            children: [
+              Expanded(
+                child: _buildActivityMetric(
+                  icon: Icons.directions_walk_rounded,
+                  label: '歩数',
+                  value: data?.steps?.toString() ?? '--',
+                  unit: '歩',
+                  color: AppColors.primary,
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingM.w),
+              Expanded(
+                child: _buildActivityMetric(
+                  icon: Icons.local_fire_department_rounded,
+                  label: '消費カロリー',
+                  value: data?.activeEnergy?.toInt().toString() ?? '--',
+                  unit: 'kcal',
+                  color: AppColors.secondary,
+                ),
+              ),
+            ],
           ),
           SizedBox(height: AppConstants.paddingM.h),
           
-          // アクティビティメトリクス
-          _buildActivityMetric(
-            icon: Icons.directions_walk_rounded,
-            label: '歩数',
-            value: data?.steps?.toString() ?? '--',
-            unit: '歩',
-            color: AppColors.primary,
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
-          
-          _buildActivityMetric(
-            icon: Icons.local_fire_department_rounded,
-            label: '消費カロリー',
-            value: data?.activeEnergy?.toInt().toString() ?? '--',
-            unit: 'kcal',
-            color: AppColors.secondary,
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
-          
-          _buildActivityMetric(
-            icon: Icons.fitness_center_rounded,
-            label: '運動時間',
-            value: data?.exerciseTime?.toString() ?? '--',
-            unit: '分',
-            color: AppColors.accent,
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
-          
-          _buildActivityMetric(
-            icon: Icons.bedtime_rounded,
-            label: '睡眠時間',
-            value: data?.sleepHours?.toStringAsFixed(1) ?? '--',
-            unit: '時間',
-            color: AppColors.info,
+          Row(
+            children: [
+              Expanded(
+                child: _buildActivityMetric(
+                  icon: Icons.fitness_center_rounded,
+                  label: '運動時間',
+                  value: data?.exerciseTime?.toString() ?? '--',
+                  unit: '分',
+                  color: AppColors.accent,
+                ),
+              ),
+              SizedBox(width: AppConstants.paddingM.w),
+              Expanded(
+                child: _buildActivityMetric(
+                  icon: Icons.bedtime_rounded,
+                  label: '睡眠時間',
+                  value: data?.sleepHours?.toStringAsFixed(1) ?? '--',
+                  unit: '時間',
+                  color: AppColors.info,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -572,30 +572,4 @@ class HealthDataPage extends HookConsumerWidget {
     );
   }
 
-  Widget _buildManualInputButton(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton.icon(
-        onPressed: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('手動入力機能は準備中です')),
-          );
-        },
-        icon: Icon(
-          Icons.edit_rounded,
-          size: 20.w,
-        ),
-        label: const Text('手動で記録'),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.surface,
-          foregroundColor: AppColors.primary,
-          elevation: 0,
-          side: BorderSide(
-            color: AppColors.primary.withOpacity(0.3),
-          ),
-          padding: EdgeInsets.symmetric(vertical: 16.h),
-        ),
-      ),
-    );
-  }
 }

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -550,7 +550,6 @@ class HealthDataPage extends HookConsumerWidget {
     final weightHistoryAsync = ref.watch(weightHistoryProvider);
 
     return Container(
-      margin: EdgeInsets.symmetric(horizontal: -AppConstants.paddingM.w), // 親のパディングを打ち消し
       child: weightHistoryAsync.when(
         data: (weightData) => WeightChartWidgetHealth(
           weightData: weightData,

--- a/lib/presentation/pages/meal_management_page.dart
+++ b/lib/presentation/pages/meal_management_page.dart
@@ -439,27 +439,6 @@ class MealManagementPage extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        '今日の栄養摂取',
-                        style: AppTextStyles.headline3,
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          // TODO: 詳細画面へ
-                        },
-                        child: Text(
-                          '詳細',
-                          style: AppTextStyles.body2.copyWith(
-                            color: AppColors.primary,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  SizedBox(height: AppConstants.paddingS.h),
                   
                   // カロリープログレスバー
                   Row(

--- a/lib/presentation/pages/meal_management_page.dart
+++ b/lib/presentation/pages/meal_management_page.dart
@@ -413,14 +413,10 @@ class MealManagementPage extends HookConsumerWidget {
         
         return nutritionAsync.when(
           data: (nutrition) {
-            const targetCalories = 2000.0;
             final currentCalories = nutrition['calories'] ?? 0.0;
             final currentProtein = nutrition['protein'] ?? 0.0;
             final currentFat = nutrition['fat'] ?? 0.0;
             final currentCarbs = nutrition['carbs'] ?? 0.0;
-            
-            final caloriesProgress = (currentCalories / targetCalories).clamp(0.0, 1.0);
-            final caloriesPercent = (caloriesProgress * 100).round();
             
             return Container(
               margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
@@ -439,40 +435,48 @@ class MealManagementPage extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  
-                  // カロリープログレスバー
+                  // カロリー（メイン表示）
+                  _buildMainNutrient(
+                    label: 'カロリー',
+                    current: currentCalories,
+                    target: AppConstants.defaultCaloriesGoal.toDouble(),
+                    unit: 'kcal',
+                    color: AppColors.primary,
+                  ),
+                  SizedBox(height: AppConstants.paddingM.h),
+
+                  // 3大栄養素（グリッド表示）
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text(
-                        'カロリー ${currentCalories.toInt()} / ${targetCalories.toInt()} kcal',
-                        style: AppTextStyles.body1,
-                      ),
-                      Text(
-                        '$caloriesPercent%',
-                        style: AppTextStyles.body2.copyWith(
-                          color: AppColors.textSecondary,
+                      Expanded(
+                        child: _buildMiniNutrientCard(
+                          label: 'タンパク質',
+                          current: currentProtein,
+                          target: AppConstants.defaultProteinGoal.toDouble(),
+                          unit: 'g',
+                          color: AppColors.info,
                         ),
                       ),
-                    ],
-                  ),
-                  SizedBox(height: AppConstants.paddingS.h),
-                  LinearProgressIndicator(
-                    value: caloriesProgress,
-                    backgroundColor: AppColors.primary.withOpacity(0.2),
-                    valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
-                    minHeight: 6.h,
-                    borderRadius: BorderRadius.circular(3.r),
-                  ),
-                  SizedBox(height: AppConstants.paddingS.h),
-                  
-                  // 3大栄養素
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children: [
-                      _buildMiniNutrient('P', '${currentProtein.toInt()}g', AppColors.info),
-                      _buildMiniNutrient('F', '${currentFat.toInt()}g', AppColors.warning),
-                      _buildMiniNutrient('C', '${currentCarbs.toInt()}g', AppColors.success),
+                      SizedBox(width: AppConstants.paddingS.w),
+                      Expanded(
+                        child: _buildMiniNutrientCard(
+                          label: '脂質',
+                          current: currentFat,
+                          target: AppConstants.defaultFatGoal.toDouble(),
+                          unit: 'g',
+                          color: AppColors.warning,
+                        ),
+                      ),
+                      SizedBox(width: AppConstants.paddingS.w),
+                      Expanded(
+                        child: _buildMiniNutrientCard(
+                          label: '炭水化物',
+                          current: currentCarbs,
+                          target: AppConstants.defaultCarbsGoal.toDouble(),
+                          unit: 'g',
+                          color: AppColors.success,
+                        ),
+                      ),
                     ],
                   ),
                 ],
@@ -486,8 +490,11 @@ class MealManagementPage extends HookConsumerWidget {
               color: AppColors.surface,
               borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
             ),
-            child: const Center(
-              child: CircularProgressIndicator(),
+            child: Center(
+              child: CircularProgressIndicator(
+                color: AppColors.primary,
+                strokeWidth: 2.w,
+              ),
             ),
           ),
           error: (error, stack) => Container(
@@ -496,19 +503,120 @@ class MealManagementPage extends HookConsumerWidget {
             decoration: BoxDecoration(
               color: AppColors.surface,
               borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+              border: Border.all(color: AppColors.error.withOpacity(0.3)),
             ),
-            child: Center(
-              child: Text(
-                'エラー: 栄養情報を取得できません',
-                style: AppTextStyles.body2.copyWith(
+            child: Column(
+              children: [
+                Icon(
+                  Icons.error_outline_rounded,
                   color: AppColors.error,
+                  size: 32.w,
                 ),
-              ),
+                SizedBox(height: AppConstants.paddingS.h),
+                Text(
+                  '栄養データの取得に失敗しました',
+                  style: AppTextStyles.body2.copyWith(color: AppColors.error),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ),
           ),
         );
       },
     );
+  }
+
+  Widget _buildMainNutrient({
+    required String label,
+    required double current,
+    required double target,
+    required String unit,
+    required Color color,
+  }) {
+    final percentage = target > 0 ? (current / target).clamp(0.0, 1.0) : 0.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '${current.toInt()} / ${target.toInt()} $unit',
+              style: AppTextStyles.numberMedium.copyWith(color: color),
+            ),
+            Text(
+              '${(percentage * 100).round()}%',
+              style: AppTextStyles.body2.copyWith(
+                color: _getPercentageColor(percentage),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: AppConstants.paddingS.h),
+        LinearProgressIndicator(
+          value: percentage,
+          backgroundColor: color.withOpacity(0.2),
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+          minHeight: 6.h,
+          borderRadius: BorderRadius.circular(3.r),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMiniNutrientCard({
+    required String label,
+    required double current,
+    required double target,
+    required String unit,
+    required Color color,
+  }) {
+    final percentage = target > 0 ? (current / target).clamp(0.0, 1.0) : 0.0;
+
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingS.w),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: AppTextStyles.caption.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: 2.h),
+          Text(
+            '${current.toInt()}g',
+            style: AppTextStyles.numberSmall.copyWith(color: color),
+          ),
+          SizedBox(height: 4.h),
+          LinearProgressIndicator(
+            value: percentage,
+            backgroundColor: Colors.white.withOpacity(0.5),
+            valueColor: AlwaysStoppedAnimation<Color>(color),
+            minHeight: 3.h,
+            borderRadius: BorderRadius.circular(1.5.r),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getPercentageColor(double percentage) {
+    if (percentage >= 0.8 && percentage <= 1.2) {
+      return AppColors.success;
+    } else if (percentage >= 0.6 && percentage <= 1.4) {
+      return AppColors.warning;
+    } else {
+      return AppColors.error;
+    }
   }
 
   Widget _buildMiniNutrient(String label, String value, Color color) {

--- a/lib/presentation/pages/meal_management_page.dart
+++ b/lib/presentation/pages/meal_management_page.dart
@@ -413,10 +413,14 @@ class MealManagementPage extends HookConsumerWidget {
         
         return nutritionAsync.when(
           data: (nutrition) {
+            const targetCalories = 2000.0;
             final currentCalories = nutrition['calories'] ?? 0.0;
             final currentProtein = nutrition['protein'] ?? 0.0;
             final currentFat = nutrition['fat'] ?? 0.0;
             final currentCarbs = nutrition['carbs'] ?? 0.0;
+            
+            final caloriesProgress = (currentCalories / targetCalories).clamp(0.0, 1.0);
+            final caloriesPercent = (caloriesProgress * 100).round();
             
             return Container(
               margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
@@ -435,48 +439,61 @@ class MealManagementPage extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // カロリー（メイン表示）
-                  _buildMainNutrient(
-                    label: 'カロリー',
-                    current: currentCalories,
-                    target: AppConstants.defaultCaloriesGoal.toDouble(),
-                    unit: 'kcal',
-                    color: AppColors.primary,
-                  ),
-                  SizedBox(height: AppConstants.paddingM.h),
-
-                  // 3大栄養素（グリッド表示）
                   Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Expanded(
-                        child: _buildMiniNutrientCard(
-                          label: 'タンパク質',
-                          current: currentProtein,
-                          target: AppConstants.defaultProteinGoal.toDouble(),
-                          unit: 'g',
-                          color: AppColors.info,
+                      Text(
+                        '今日の栄養摂取',
+                        style: AppTextStyles.headline3,
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          // TODO: 詳細画面へ
+                        },
+                        child: Text(
+                          '詳細',
+                          style: AppTextStyles.body2.copyWith(
+                            color: AppColors.primary,
+                          ),
                         ),
                       ),
-                      SizedBox(width: AppConstants.paddingS.w),
-                      Expanded(
-                        child: _buildMiniNutrientCard(
-                          label: '脂質',
-                          current: currentFat,
-                          target: AppConstants.defaultFatGoal.toDouble(),
-                          unit: 'g',
-                          color: AppColors.warning,
+                    ],
+                  ),
+                  SizedBox(height: AppConstants.paddingS.h),
+                  
+                  // カロリープログレスバー
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'カロリー ${currentCalories.toInt()} / ${targetCalories.toInt()} kcal',
+                        style: AppTextStyles.body1,
+                      ),
+                      Text(
+                        '$caloriesPercent%',
+                        style: AppTextStyles.body2.copyWith(
+                          color: AppColors.textSecondary,
                         ),
                       ),
-                      SizedBox(width: AppConstants.paddingS.w),
-                      Expanded(
-                        child: _buildMiniNutrientCard(
-                          label: '炭水化物',
-                          current: currentCarbs,
-                          target: AppConstants.defaultCarbsGoal.toDouble(),
-                          unit: 'g',
-                          color: AppColors.success,
-                        ),
-                      ),
+                    ],
+                  ),
+                  SizedBox(height: AppConstants.paddingS.h),
+                  LinearProgressIndicator(
+                    value: caloriesProgress,
+                    backgroundColor: AppColors.primary.withOpacity(0.2),
+                    valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
+                    minHeight: 6.h,
+                    borderRadius: BorderRadius.circular(3.r),
+                  ),
+                  SizedBox(height: AppConstants.paddingS.h),
+                  
+                  // 3大栄養素
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      _buildMiniNutrient('P', '${currentProtein.toInt()}g', AppColors.info),
+                      _buildMiniNutrient('F', '${currentFat.toInt()}g', AppColors.warning),
+                      _buildMiniNutrient('C', '${currentCarbs.toInt()}g', AppColors.success),
                     ],
                   ),
                 ],
@@ -490,11 +507,8 @@ class MealManagementPage extends HookConsumerWidget {
               color: AppColors.surface,
               borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
             ),
-            child: Center(
-              child: CircularProgressIndicator(
-                color: AppColors.primary,
-                strokeWidth: 2.w,
-              ),
+            child: const Center(
+              child: CircularProgressIndicator(),
             ),
           ),
           error: (error, stack) => Container(
@@ -503,127 +517,19 @@ class MealManagementPage extends HookConsumerWidget {
             decoration: BoxDecoration(
               color: AppColors.surface,
               borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
-              border: Border.all(color: AppColors.error.withOpacity(0.3)),
             ),
-            child: Column(
-              children: [
-                Icon(
-                  Icons.error_outline_rounded,
+            child: Center(
+              child: Text(
+                'エラー: 栄養情報を取得できません',
+                style: AppTextStyles.body2.copyWith(
                   color: AppColors.error,
-                  size: 32.w,
                 ),
-                SizedBox(height: AppConstants.paddingS.h),
-                Text(
-                  '栄養データの取得に失敗しました',
-                  style: AppTextStyles.body2.copyWith(color: AppColors.error),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+              ),
             ),
           ),
         );
       },
     );
-  }
-
-  Widget _buildMainNutrient({
-    required String label,
-    required double current,
-    required double target,
-    required String unit,
-    required Color color,
-  }) {
-    final percentage = target > 0 ? (current / target).clamp(0.0, 1.0) : 0.0;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              label,
-              style: AppTextStyles.body1.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            Text(
-              '${(percentage * 100).round()}%',
-              style: AppTextStyles.body2.copyWith(
-                color: _getPercentageColor(percentage),
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
-        ),
-        SizedBox(height: AppConstants.paddingS.h),
-        Text(
-          '${current.toInt()} / ${target.toInt()} $unit',
-          style: AppTextStyles.numberMedium.copyWith(color: color),
-        ),
-        SizedBox(height: AppConstants.paddingS.h),
-        LinearProgressIndicator(
-          value: percentage,
-          backgroundColor: color.withOpacity(0.2),
-          valueColor: AlwaysStoppedAnimation<Color>(color),
-          minHeight: 6.h,
-          borderRadius: BorderRadius.circular(3.r),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildMiniNutrientCard({
-    required String label,
-    required double current,
-    required double target,
-    required String unit,
-    required Color color,
-  }) {
-    final percentage = target > 0 ? (current / target).clamp(0.0, 1.0) : 0.0;
-
-    return Container(
-      padding: EdgeInsets.all(AppConstants.paddingS.w),
-      decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(AppConstants.radiusM.r),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: AppTextStyles.caption.copyWith(
-              color: color,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          SizedBox(height: 2.h),
-          Text(
-            '${current.toInt()}g',
-            style: AppTextStyles.numberSmall.copyWith(color: color),
-          ),
-          SizedBox(height: 4.h),
-          LinearProgressIndicator(
-            value: percentage,
-            backgroundColor: Colors.white.withOpacity(0.5),
-            valueColor: AlwaysStoppedAnimation<Color>(color),
-            minHeight: 3.h,
-            borderRadius: BorderRadius.circular(1.5.r),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Color _getPercentageColor(double percentage) {
-    if (percentage >= 0.8 && percentage <= 1.2) {
-      return AppColors.success;
-    } else if (percentage >= 0.6 && percentage <= 1.4) {
-      return AppColors.warning;
-    } else {
-      return AppColors.error;
-    }
   }
 
   Widget _buildMiniNutrient(String label, String value, Color color) {

--- a/lib/presentation/widgets/nutrition_summary_card.dart
+++ b/lib/presentation/widgets/nutrition_summary_card.dart
@@ -36,11 +36,6 @@ class NutritionSummaryCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '今日の栄養バランス',
-            style: AppTextStyles.headline3,
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
           
           // カロリー（メイン表示）
           _buildMainNutrient(

--- a/lib/presentation/widgets/nutrition_summary_card.dart
+++ b/lib/presentation/widgets/nutrition_summary_card.dart
@@ -102,10 +102,8 @@ class NutritionSummaryCard extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              label,
-              style: AppTextStyles.body1.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
+              '${current.toInt()} / ${target.toInt()} $unit',
+              style: AppTextStyles.numberMedium.copyWith(color: color),
             ),
             Text(
               '${percentage.toPercentage()}%',
@@ -115,11 +113,6 @@ class NutritionSummaryCard extends StatelessWidget {
               ),
             ),
           ],
-        ),
-        SizedBox(height: AppConstants.paddingS.h),
-        Text(
-          '${current.toInt()} / ${target.toInt()} $unit',
-          style: AppTextStyles.numberMedium.copyWith(color: color),
         ),
         SizedBox(height: AppConstants.paddingS.h),
         LinearProgressIndicator(

--- a/lib/presentation/widgets/steps_progress_card.dart
+++ b/lib/presentation/widgets/steps_progress_card.dart
@@ -37,21 +37,6 @@ class StepsProgressCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Icon(
-                Icons.directions_walk_rounded,
-                color: AppColors.primary,
-                size: 24.w,
-              ),
-              SizedBox(width: AppConstants.paddingS.w),
-              Text(
-                '今日の歩数',
-                style: AppTextStyles.headline3,
-              ),
-            ],
-          ),
-          SizedBox(height: AppConstants.paddingM.h),
           
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
## Summary

• ホーム画面と食事管理画面のラベル表示を簡素化
• 身体活動画面のレイアウトを改善
• 栄養カードのデザインを統一

## 変更内容

### ホーム画面
- 「今日の栄養バランス」「今日の歩数」ラベルを削除
- カロリー摂取率の%表示をkcal行の右端に移動

### 食事管理画面  
- 「今日の栄養摂取」ラベルを削除
- 栄養カードをホーム画面と同じデザインに統一
- カロリー摂取率の%表示をkcal行の右端に移動

### 身体活動画面
- 「体重・体脂肪率」「直近24時間の活動」ラベルを削除
- 活動メトリクスを1列4行から2列2行に変更
- 「手動で記録」機能を削除
- 負のmarginエラーを修正

## Test plan

- [ ] ホーム画面の表示確認
- [ ] 食事管理画面の栄養カード表示確認
- [ ] 身体活動画面のレイアウト確認
- [ ] アサーションエラーが解消されていることを確認