### PR TITLE
refactor: 設定画面UIを簡素化と全画面レイアウト統一

### DIFF
--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -215,7 +215,11 @@ class HealthDataPage extends HookConsumerWidget {
   Widget _buildPermissionCard(BuildContext context, WidgetRef ref) {
     return Container(
       padding: EdgeInsets.all(AppConstants.paddingM.w),
-      margin: EdgeInsets.only(bottom: AppConstants.paddingM.h),
+      margin: EdgeInsets.only(
+        bottom: AppConstants.paddingM.h,
+        left: AppConstants.paddingM.w,
+        right: AppConstants.paddingM.w,
+      ),
       decoration: BoxDecoration(
         color: AppColors.warning.withOpacity(0.1),
         borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
@@ -286,7 +290,11 @@ class HealthDataPage extends HookConsumerWidget {
   Widget _buildLoadingCard() {
     return Container(
       height: 120.h,
-      margin: EdgeInsets.only(bottom: AppConstants.paddingM.h),
+      margin: EdgeInsets.only(
+        bottom: AppConstants.paddingM.h,
+        left: AppConstants.paddingM.w,
+        right: AppConstants.paddingM.w,
+      ),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
@@ -303,7 +311,11 @@ class HealthDataPage extends HookConsumerWidget {
   Widget _buildErrorCard(String message) {
     return Container(
       padding: EdgeInsets.all(AppConstants.paddingM.w),
-      margin: EdgeInsets.only(bottom: AppConstants.paddingM.h),
+      margin: EdgeInsets.only(
+        bottom: AppConstants.paddingM.h,
+        left: AppConstants.paddingM.w,
+        right: AppConstants.paddingM.w,
+      ),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
@@ -329,6 +341,7 @@ class HealthDataPage extends HookConsumerWidget {
 
   Widget _buildWeightCard(PersonalDataTableData? data, WidgetRef ref) {
     return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
       padding: EdgeInsets.all(AppConstants.paddingM.w),
       decoration: BoxDecoration(
         color: AppColors.surface,
@@ -383,6 +396,7 @@ class HealthDataPage extends HookConsumerWidget {
 
   Widget _buildActivityCard(PersonalDataTableData? data) {
     return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
       padding: EdgeInsets.all(AppConstants.paddingM.w),
       decoration: BoxDecoration(
         color: AppColors.surface,

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -29,7 +29,6 @@ class HealthDataPage extends HookConsumerWidget {
           },
           child: SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: EdgeInsets.all(AppConstants.paddingM.w),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -74,14 +73,16 @@ class HealthDataPage extends HookConsumerWidget {
     final selectedDate = ref.watch(selectedDateProvider);
     final isToday = _isToday(selectedDate);
     
-    return Column(
-      children: [
-        Row(
-          children: [
-            Text(
-              '身体・活動',
-              style: AppTextStyles.headline2,
-            ),
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingM.w),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Text(
+                '身体・活動',
+                style: AppTextStyles.headline2,
+              ),
             const Spacer(),
             IconButton(
               onPressed: () {
@@ -104,10 +105,11 @@ class HealthDataPage extends HookConsumerWidget {
             ),
           ],
         ),
-        // 日付選択バーは非表示（機能は残す）
-        // SizedBox(height: AppConstants.paddingM.h),
-        // _buildDateSelector(context, ref, selectedDate, isToday),
-      ],
+          // 日付選択バーは非表示（機能は残す）
+          // SizedBox(height: AppConstants.paddingM.h),
+          // _buildDateSelector(context, ref, selectedDate, isToday),
+        ],
+      ),
     );
   }
 

--- a/lib/presentation/pages/health_data_page.dart
+++ b/lib/presentation/pages/health_data_page.dart
@@ -34,8 +34,7 @@ class HealthDataPage extends HookConsumerWidget {
               children: [
                 // ヘッダー
                 _buildHeader(context, ref),
-                SizedBox(height: AppConstants.paddingL.h),
-
+                
                 // 権限確認カード
                 healthPermission.when(
                   data: (hasPermission) => hasPermission

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -34,8 +34,7 @@ class SettingsPage extends HookConsumerWidget {
             children: [
               // ヘッダー
               _buildHeader(context),
-              SizedBox(height: AppConstants.paddingL.h),
-
+              
               // 設定項目（一覧表示）
               Container(
                 margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -120,6 +120,12 @@ class SettingsPage extends HookConsumerWidget {
             '設定',
             style: AppTextStyles.headline2,
           ),
+          const Spacer(),
+          // 他の画面のIconButtonと同じ高さを確保するための透明なダミーアイコン
+          SizedBox(
+            width: 48.w, // IconButtonのデフォルトサイズ
+            height: 48.h,
+          ),
         ],
       ),
     );

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -29,19 +29,16 @@ class SettingsPage extends HookConsumerWidget {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: SingleChildScrollView(
-          padding: EdgeInsets.all(AppConstants.paddingM.w),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // ヘッダー
-              Text(
-                '設定',
-                style: AppTextStyles.headline2,
-              ),
+              _buildHeader(context),
               SizedBox(height: AppConstants.paddingL.h),
 
               // 設定項目（一覧表示）
               Container(
+                margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
                 decoration: BoxDecoration(
                   color: AppColors.surface,
                   borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
@@ -103,10 +100,27 @@ class SettingsPage extends HookConsumerWidget {
               SizedBox(height: AppConstants.paddingXL.h),
 
               // MVP版の説明
-              _buildMVPInfo(),
+              Container(
+                margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
+                child: _buildMVPInfo(),
+              ),
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingM.w),
+      child: Row(
+        children: [
+          Text(
+            '設定',
+            style: AppTextStyles.headline2,
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -40,65 +40,64 @@ class SettingsPage extends HookConsumerWidget {
               ),
               SizedBox(height: AppConstants.paddingL.h),
 
-              // 目標設定セクション
-              _buildSection(
-                title: '目標設定',
-                children: [
-                  _buildSettingItem(
-                    icon: Icons.flag_rounded,
-                    title: '体重目標',
-                    subtitle: '${weightGoal.toStringAsFixed(1)} kg',
-                    onTap: () => _showWeightGoalDialog(context, ref),
-                  ),
-                  _buildSettingItem(
-                    icon: Icons.restaurant_rounded,
-                    title: '1日の栄養目標',
-                    subtitle: '${caloriesGoal.toInt()} kcal, タンパク質 ${proteinGoal.toInt()}g',
-                    onTap: () => _showNutritionGoalDialog(context, ref),
-                  ),
-                ],
-              ),
-
-              SizedBox(height: AppConstants.paddingL.h),
-
-              // アプリ設定セクション
-              _buildSection(
-                title: 'アプリ設定',
-                children: [
-                  _buildSettingItem(
-                    icon: Icons.health_and_safety_rounded,
-                    title: 'HealthKit連携',
-                    subtitle: '健康データの同期設定',
-                    onTap: () => _showComingSoonSnackBar(context),
-                  ),
-                ],
-              ),
-
-              SizedBox(height: AppConstants.paddingL.h),
-
-              // その他セクション
-              _buildSection(
-                title: 'その他',
-                children: [
-                  _buildSettingItem(
-                    icon: Icons.help_outline_rounded,
-                    title: 'ヘルプ',
-                    subtitle: '使い方とFAQ',
-                    onTap: () => _showComingSoonSnackBar(context),
-                  ),
-                  _buildSettingItem(
-                    icon: Icons.privacy_tip_rounded,
-                    title: 'プライバシーポリシー',
-                    subtitle: 'データの取り扱いについて',
-                    onTap: () => _showComingSoonSnackBar(context),
-                  ),
-                  _buildSettingItem(
-                    icon: Icons.info_outline_rounded,
-                    title: 'アプリについて',
-                    subtitle: 'バージョン ${AppConstants.appVersion}',
-                    onTap: () => _showAboutDialog(context),
-                  ),
-                ],
+              // 設定項目（一覧表示）
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColors.surface,
+                  borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.05),
+                      blurRadius: 8.r,
+                      offset: Offset(0, 2.h),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: [
+                    _buildSettingItem(
+                      icon: Icons.flag_rounded,
+                      title: '体重目標',
+                      subtitle: '${weightGoal.toStringAsFixed(1)} kg',
+                      onTap: () => _showWeightGoalDialog(context, ref),
+                    ),
+                    _buildDivider(),
+                    _buildSettingItem(
+                      icon: Icons.restaurant_rounded,
+                      title: '1日の栄養目標',
+                      subtitle: '${caloriesGoal.toInt()} kcal, タンパク質 ${proteinGoal.toInt()}g',
+                      onTap: () => _showNutritionGoalDialog(context, ref),
+                    ),
+                    _buildDivider(),
+                    _buildSettingItem(
+                      icon: Icons.health_and_safety_rounded,
+                      title: 'HealthKit連携',
+                      subtitle: '健康データの同期設定',
+                      onTap: () => _showComingSoonSnackBar(context),
+                    ),
+                    _buildDivider(),
+                    _buildSettingItem(
+                      icon: Icons.help_outline_rounded,
+                      title: 'ヘルプ',
+                      subtitle: '使い方とFAQ',
+                      onTap: () => _showComingSoonSnackBar(context),
+                    ),
+                    _buildDivider(),
+                    _buildSettingItem(
+                      icon: Icons.privacy_tip_rounded,
+                      title: 'プライバシーポリシー',
+                      subtitle: 'データの取り扱いについて',
+                      onTap: () => _showComingSoonSnackBar(context),
+                    ),
+                    _buildDivider(),
+                    _buildSettingItem(
+                      icon: Icons.info_outline_rounded,
+                      title: 'アプリについて',
+                      subtitle: 'バージョン ${AppConstants.appVersion}',
+                      onTap: () => _showAboutDialog(context),
+                    ),
+                  ],
+                ),
               ),
 
               SizedBox(height: AppConstants.paddingXL.h),
@@ -112,37 +111,11 @@ class SettingsPage extends HookConsumerWidget {
     );
   }
 
-  Widget _buildSection({
-    required String title,
-    required List<Widget> children,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: AppTextStyles.headline3.copyWith(
-            color: AppColors.textSecondary,
-          ),
-        ),
-        SizedBox(height: AppConstants.paddingM.h),
-        Container(
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(AppConstants.radiusL.r),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacity(0.05),
-                blurRadius: 8.r,
-                offset: Offset(0, 2.h),
-              ),
-            ],
-          ),
-          child: Column(
-            children: children,
-          ),
-        ),
-      ],
+  Widget _buildDivider() {
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
+      height: 1.h,
+      color: AppColors.textSecondary.withOpacity(0.1),
     );
   }
 
@@ -185,7 +158,7 @@ class SettingsPage extends HookConsumerWidget {
       onTap: onTap,
       contentPadding: EdgeInsets.symmetric(
         horizontal: AppConstants.paddingM.w,
-        vertical: AppConstants.paddingS.h,
+        vertical: AppConstants.paddingXS.h,
       ),
     );
   }
@@ -229,7 +202,7 @@ class SettingsPage extends HookConsumerWidget {
       ),
       contentPadding: EdgeInsets.symmetric(
         horizontal: AppConstants.paddingM.w,
-        vertical: AppConstants.paddingS.h,
+        vertical: AppConstants.paddingXS.h,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- セクションタイトル（目標設定、アプリ設定、その他）を削除
- 全ての設定項目を一つのカードに統合して一覧表示
- 設定項目間に区切り線を追加して視覚的に分離
- 全画面でヘッダー高さとカード間隔を統一

## 変更内容
### 設定画面の簡素化
- セクションタイトルテキストを削除してスッキリした見た目に
- 3つの分離されたカードを1つの統合カードに変更
- 設定項目間に薄いグレーの区切り線を追加
- 設定項目の縦間隔をpaddingSからpaddingXSに変更してコンパクト化

### 全画面レイアウト統一
- **ヘッダー高さ統一**: 設定画面にSpacerと透明なSizedBoxを追加してIconButtonと同じ48x48の高さを確保
- **ヘッダー構造統一**: 全画面で`Container + padding: EdgeInsets.all(AppConstants.paddingM.w)`に統一
- **ヘッダー間隔統一**: ヘッダー後の隙間を削除して食事管理画面と同じ間隔に統一
- **カードマージン統一**: 全カードに`EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w)`を適用

### 技術的改善
- 身体・活動画面の二重パディングを解消（ScrollViewからpadding削除）
- 身体・活動画面の構造をContainerベースに統一（Column→Container+Column）
- 不要な`_buildSection`メソッドを削除
- 新しく`_buildDivider`メソッドと`_buildHeader`メソッドを追加

## Test plan
- [x] 設定画面が正常に表示されること
- [x] 全ての設定項目が一つのカード内に表示されること  
- [x] 設定項目間に区切り線が表示されること
- [x] 設定項目の間隔が適切に狭くなっていること
- [x] 各設定項目のタップ動作が正常に機能すること
- [x] 全画面でヘッダー高さが統一されていること
- [x] 全画面でヘッダーとコンテンツ間の隙間が統一されていること
- [x] 全画面でカードと画面端の間隔が統一されていること