### PR TITLE
ホーム画面ヘッダーを他画面と統一

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -31,13 +31,11 @@ class HomePage extends HookConsumerWidget {
           },
           child: SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: EdgeInsets.all(AppConstants.paddingM.w),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // ヘッダー
                 _buildHeader(context, ref),
-                SizedBox(height: AppConstants.paddingL.h),
 
                 // 今日の栄養バランス
                 todayNutrition.when(
@@ -129,48 +127,24 @@ class HomePage extends HookConsumerWidget {
 
   Widget _buildHeader(BuildContext context, WidgetRef ref) {
     final now = DateTime.now();
-    final greeting = _getTimeBasedGreeting(ref);
     final dateText = '${now.month}月${now.day}日';
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          greeting,
-          style: AppTextStyles.headline2.copyWith(
-            color: AppColors.textSecondary,
+    return Container(
+      padding: EdgeInsets.all(AppConstants.paddingM.w),
+      child: Row(
+        children: [
+          Text(
+            dateText,
+            style: AppTextStyles.headline2,
           ),
-        ),
-        SizedBox(height: 4.h),
-        Row(
-          children: [
-            Text(
-              dateText,
-              style: AppTextStyles.headline1.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const Spacer(),
-            Container(
-              padding: EdgeInsets.symmetric(
-                horizontal: 12.w,
-                vertical: 6.h,
-              ),
-              decoration: BoxDecoration(
-                color: AppColors.primary.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(16.r),
-              ),
-              child: Text(
-                'MVP版',
-                style: AppTextStyles.caption.copyWith(
-                  color: AppColors.primary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ],
+          const Spacer(),
+          // 他の画面のIconButtonと同じ高さを確保するための透明なダミーアイコン
+          SizedBox(
+            width: 48.w, // IconButtonのデフォルトサイズ
+            height: 48.h,
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/presentation/widgets/nutrition_summary_card.dart
+++ b/lib/presentation/widgets/nutrition_summary_card.dart
@@ -24,6 +24,7 @@ class NutritionSummaryCard extends ConsumerWidget {
     final carbs = nutrition['carbs'] ?? 0.0;
 
     return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
       padding: EdgeInsets.all(AppConstants.paddingM.w),
       decoration: BoxDecoration(
         color: AppColors.surface,

--- a/lib/presentation/widgets/steps_progress_card.dart
+++ b/lib/presentation/widgets/steps_progress_card.dart
@@ -22,6 +22,7 @@ class StepsProgressCard extends StatelessWidget {
     final percentage = goal > 0 ? (steps / goal).clamp(0.0, 1.0) : 0.0;
 
     return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
       padding: EdgeInsets.all(AppConstants.paddingM.w),
       decoration: BoxDecoration(
         color: AppColors.surface,

--- a/lib/presentation/widgets/weight_chart_widget_home.dart
+++ b/lib/presentation/widgets/weight_chart_widget_home.dart
@@ -99,6 +99,7 @@ class _WeightChartWidgetHomeState extends State<WeightChartWidgetHome>
     final isDark = theme.brightness == Brightness.dark;
     
     return Container(
+      margin: EdgeInsets.symmetric(horizontal: AppConstants.paddingM.w),
       decoration: BoxDecoration(
         color: isDark ? Colors.grey[900] : Colors.white,
         borderRadius: BorderRadius.circular(20.r),


### PR DESCRIPTION
## Summary
- ホーム画面のヘッダーを他の画面（食事管理、身体活動、設定）と統一
- メッセージ表示を削除してシンプルに
- 日付テキストのサイズを他画面のタイトルと同じheadline2に変更
- Container + padding構造を採用して他画面と同じレイアウトに統一
- ダミーSizedBoxを使用してヘッダー高さを他画面と統一

## Test plan
- [x] ホーム画面のヘッダー高さが他画面と同じになっていることを確認
- [x] 日付テキストのサイズが他画面のタイトルと同じになっていることを確認
- [x] メッセージが表示されなくなっていることを確認
- [x] レイアウトが他画面と統一されていることを確認